### PR TITLE
Update vite.config.ts

### DIFF
--- a/GUI/vite.config.ts
+++ b/GUI/vite.config.ts
@@ -8,9 +8,9 @@ import path from 'path';
 export default defineConfig({
   envPrefix: 'REACT_APP_',
   plugins: [react(), tsconfigPaths(), svgr()],
-   base: '/burokratt/', //Change this according to your reverse proxy subpath
+   base: '/training/', //Change this according to your reverse proxy subpath
   build: {
-    outDir: './training',
+    outDir: './burokratt',
     target: 'es2015',
     emptyOutDir: true,
   },

--- a/GUI/vite.config.ts
+++ b/GUI/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   plugins: [react(), tsconfigPaths(), svgr()],
    base: '/burokratt/', //Change this according to your reverse proxy subpath
   build: {
-    outDir: './burokratt',
+    outDir: './training',
     target: 'es2015',
     emptyOutDir: true,
   },

--- a/GUI/vite.config.ts
+++ b/GUI/vite.config.ts
@@ -8,7 +8,7 @@ import path from 'path';
 export default defineConfig({
   envPrefix: 'REACT_APP_',
   plugins: [react(), tsconfigPaths(), svgr()],
-  // base: '/burokratt/',
+   base: '/burokratt/', //Change this according to your reverse proxy subpath
   build: {
     outDir: './burokratt',
     target: 'es2015',


### PR DESCRIPTION
To give a path to resources when using the proxy subpath, a path must be given to it.