### PR TITLE
Added parameters to the urls in the DSL folder

### DIFF
--- a/DSL/OpenSearch/README.md
+++ b/DSL/OpenSearch/README.md
@@ -1,7 +1,7 @@
 # Bürokratt's Training Module DSL Opensearch commands
 ##### To reset indexes
 ```
-curl -XDELETE 'http://localhost:9200/*' -u admin:admin --insecure
+curl -XDELETE '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/*' -u admin:admin --insecure
 ```
 ##### To load all indexes with mock data
 ```
@@ -10,245 +10,245 @@ sh init.sh
 ## Responses
 ##### Create response index
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/responses" -ku admin:admin --data-binary "@fieldMappings/responses.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/responses" -ku admin:admin --data-binary "@fieldMappings/responses.json"
 ```
 ##### Add mock data from response.json file
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/responses/_bulk" -ku admin:admin --data-binary "@mock/responses.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/responses/_bulk" -ku admin:admin --data-binary "@mock/responses.json"
 ```
 ##### Test query to index to validate that mock data is there
 ```
-curl -H 'Content-Type: application/json' -X GET "http://localhost:9200/responses/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"name":"utter_andmekaitse_küsimused"}}}'
+curl -H 'Content-Type: application/json' -X GET "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/responses/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"name":"utter_andmekaitse_küsimused"}}}'
 ```
 ##### Templates for searching responses
 ```
-curl -L -X POST 'http://localhost:9200/_scripts/response-with-name-and-text' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/response-with-name-and-text.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/response-with-name-and-text' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/response-with-name-and-text.json"
 ```
 ##### Test template
 ```
-curl -L -X GET 'http://localhost:9200/responses/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "response-with-name-and-text", "params": {"response_name": "fallback", "response_text": "kas"}}'
+curl -L -X GET '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/responses/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "response-with-name-and-text", "params": {"response_name": "fallback", "response_text": "kas"}}'
 ```
 ## Intents
 ##### Create intents index
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/intents" -ku admin:admin --data-binary "@fieldMappings/intents.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/intents" -ku admin:admin --data-binary "@fieldMappings/intents.json"
 ```
 ##### Add mock data from intents.json file
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/intents/_bulk" -ku admin:admin --data-binary "@mock/intents.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/intents/_bulk" -ku admin:admin --data-binary "@mock/intents.json"
 ```
 ##### Test query to index to validate that mock data is there
 ```
-curl -H 'Content-Type: application/json' -X GET "http://localhost:9200/intents/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"intent":"common_tervitus"}}}'
+curl -H 'Content-Type: application/json' -X GET "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/intents/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"intent":"common_tervitus"}}}'
 ```
 ##### Templates for searching intents
 ```
-curl -L -X POST 'http://localhost:9200/_scripts/intent-with-name' -H 'Content-Type: application/json' --data-binary "@templates/intent-with-name.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/intent-with-name' -H 'Content-Type: application/json' --data-binary "@templates/intent-with-name.json"
 ```
 ##### Test template
 ```
-curl -L -X GET 'http://localhost:9200/intents/_search/template' -H 'Content-Type: application/json' --data-raw '{"id": "intent-with-name", "params": {"intent": "andmekaitse"}}'
+curl -L -X GET '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/intents/_search/template' -H 'Content-Type: application/json' --data-raw '{"id": "intent-with-name", "params": {"intent": "andmekaitse"}}'
 ```
 ##### Templates for getting intents with example count
 ```
-curl -L -X POST 'http://localhost:9200/_scripts/intents-with-examples-count' -H 'Content-Type: application/json' --data-binary "@templates/intents-with-examples-count.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/intents-with-examples-count' -H 'Content-Type: application/json' --data-binary "@templates/intents-with-examples-count.json"
 ```
 ##### Test template
 ```
-curl -L -X GET 'http://localhost:9200/intents/_search/template' -H 'Content-Type: application/json' --data-raw '{"id": "intents-with-examples-count", "params": {"intent": "andmekaitse"}}'
+curl -L -X GET '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/intents/_search/template' -H 'Content-Type: application/json' --data-raw '{"id": "intents-with-examples-count", "params": {"intent": "andmekaitse"}}'
 ```
 ## Rules
 ##### Create rules index
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/rules" -ku admin:admin --data-binary "@fieldMappings/rules.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/rules" -ku admin:admin --data-binary "@fieldMappings/rules.json"
 ```
 ##### Add mock data from rules.json file
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/rules/_bulk" -ku admin:admin --data-binary "@mock/rules.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/rules/_bulk" -ku admin:admin --data-binary "@mock/rules.json"
 ```
 ##### Test query to index to validate that mock data is there
 ```
-curl -H 'Content-Type: application/json' -X GET "http://localhost:9200/rules/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"rule":"common_tervitus"}}}'
+curl -H 'Content-Type: application/json' -X GET "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/rules/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"rule":"common_tervitus"}}}'
 ```
 ##### Templates for searching rules
 ```
-curl -L -X POST 'http://localhost:9200/_scripts/rule-with-name' -H 'Content-Type: application/json' --data-binary "@templates/rule-with-name.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/rule-with-name' -H 'Content-Type: application/json' --data-binary "@templates/rule-with-name.json"
 ```
 ##### Test template
 ```
-curl -L -X GET 'http://localhost:9200/rules/_search/template' -H 'Content-Type: application/json' --data-raw '{"id": "rule-with-name", "params": {"rule": "rahvaarv_olemas"}}'
+curl -L -X GET '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/rules/_search/template' -H 'Content-Type: application/json' --data-raw '{"id": "rule-with-name", "params": {"rule": "rahvaarv_olemas"}}'
 ```
 ##### Templates for searching forms in rules
 ```
-curl -L -X POST 'http://localhost:9200/_scripts/rule-with-forms' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/rule-with-forms.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/rule-with-forms' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/rule-with-forms.json"
 ```
 ##### Templates for searching responses in rules
 ```
-curl -L -X POST 'http://localhost:9200/_scripts/rule-with-responses' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/rule-with-responses.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/rule-with-responses' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/rule-with-responses.json"
 ```
 ##### Templates for searching slots in rules
 ```
-curl -L -X POST 'http://localhost:9200/_scripts/rule-with-slots' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/rule-with-slots.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/rule-with-slots' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/rule-with-slots.json"
 ```
 ##### Test form template
 ```
-curl -L -X GET 'http://localhost:9200/rules/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "rule-with-forms", "params": {"form": "custom_fallback_form"}}'
+curl -L -X GET '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/rules/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "rule-with-forms", "params": {"form": "custom_fallback_form"}}'
 ```
 ##### Test response template
 ```
-curl -L -X GET 'http://localhost:9200/rules/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "rule-with-responses", "params": {"response": "utter_common_tervitus"}}'
+curl -L -X GET '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/rules/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "rule-with-responses", "params": {"response": "utter_common_tervitus"}}'
 ```
 ##### Test slot template
 ```
-curl -L -X GET 'http://localhost:9200/rules/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "rule-with-slots", "params": {"slot": "common_teenus_ilm_asukoht"}}'
+curl -L -X GET '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/rules/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "rule-with-slots", "params": {"slot": "common_teenus_ilm_asukoht"}}'
 ```
 ## Stories
 ##### Create stories index
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/stories" -ku admin:admin --data-binary "@fieldMappings/stories.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/stories" -ku admin:admin --data-binary "@fieldMappings/stories.json"
 ```
 ##### Add mock data from stories.json file
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/stories/_bulk" -ku admin:admin --data-binary "@mock/stories.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/stories/_bulk" -ku admin:admin --data-binary "@mock/stories.json"
 ```
 ##### Test query to index to validate that mock data is there
 ```
-curl -H 'Content-Type: application/json' -X GET "http://localhost:9200/stories/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"story":"tervitamine"}}}'
+curl -H 'Content-Type: application/json' -X GET "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/stories/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"story":"tervitamine"}}}'
 ```
 ##### Templates for searching stories
 ```
-curl -L -X POST 'http://localhost:9200/_scripts/story-with-name' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/story-with-name.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/story-with-name' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/story-with-name.json"
 ```
 ##### Test template
 ```
-curl -L -X GET 'http://localhost:9200/stories/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "story-with-name", "params": {"story": "tervitamine"}}'
+curl -L -X GET '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/stories/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "story-with-name", "params": {"story": "tervitamine"}}'
 ```
 ##### Templates for searching forms in stories
 ```
-curl -L -X POST 'http://localhost:9200/_scripts/story-with-forms' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/story-with-forms.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/story-with-forms' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/story-with-forms.json"
 ```
 ##### Templates for searching responses in stories
 ```
-curl -L -X POST 'http://localhost:9200/_scripts/story-with-responses' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/story-with-responses.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/story-with-responses' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/story-with-responses.json"
 ```
 ##### Templates for searching slots in stories
 ```
-curl -L -X POST 'http://localhost:9200/_scripts/story-with-slots' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/story-with-slots.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/story-with-slots' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/story-with-slots.json"
 ```
 ##### Test forms template
 ```
-curl -L -X GET 'http://localhost:9200/stories/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "story-with-forms", "params": {"form": "custom_fallback_form"}}'
+curl -L -X GET '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/stories/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "story-with-forms", "params": {"form": "custom_fallback_form"}}'
 ```
 ##### Test responses template
 ```
-curl -L -X GET 'http://localhost:9200/stories/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "story-with-responses", "params": {"response": "utter_andmekaitse_küsimused"}}'
+curl -L -X GET '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/stories/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "story-with-responses", "params": {"response": "utter_andmekaitse_küsimused"}}'
 ```
 ##### Test slots template
 ```
-curl -L -X GET 'http://localhost:9200/stories/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "rule-with-slots", "params": {"slot": "asukoht"}}'
+curl -L -X GET '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/stories/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "rule-with-slots", "params": {"slot": "asukoht"}}'
 ```
 ## Test stories
 ##### Create test stories index
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/test-stories" -ku admin:admin --data-binary "@fieldMappings/test-stories.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/test-stories" -ku admin:admin --data-binary "@fieldMappings/test-stories.json"
 ```
 ##### Add mock data from test-stories.json file
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/test-stories/_bulk" -ku admin:admin --data-binary "@mock/test-stories.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/test-stories/_bulk" -ku admin:admin --data-binary "@mock/test-stories.json"
 ```
 ##### Test query to index to validate that mock data is there
 ```
-curl -H 'Content-Type: application/json' -X GET "http://localhost:9200/test-stories/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"story":"common_tervitus"}}}'
+curl -H 'Content-Type: application/json' -X GET "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/test-stories/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"story":"common_tervitus"}}}'
 ```
 ##### Templates for searching test stories
 ```
-curl -L -X POST 'http://localhost:9200/_scripts/test-story-with-name' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/test-story-with-name.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/test-story-with-name' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/test-story-with-name.json"
 ```
 ##### Test template
 ```
-curl -L -X GET 'http://localhost:9200/test-stories/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "test-story-with-name", "params": {"story": "common_tervitus"}}'
+curl -L -X GET '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/test-stories/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "test-story-with-name", "params": {"story": "common_tervitus"}}'
 ```
 ## Forms
 ##### Create forms index
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/forms" -ku admin:admin --data-binary "@fieldMappings/forms.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/forms" -ku admin:admin --data-binary "@fieldMappings/forms.json"
 ```
 ##### Add mock data from forms.json file
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/forms/_bulk" -ku admin:admin --data-binary "@mock/forms.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/forms/_bulk" -ku admin:admin --data-binary "@mock/forms.json"
 ```
 ##### Test query to index to validate that mock data is there
 ```
-curl -H 'Content-Type: application/json' -X GET "http://localhost:9200/forms/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"form":"custom_fallback_form"}}}'
+curl -H 'Content-Type: application/json' -X GET "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/forms/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"form":"custom_fallback_form"}}}'
 ```
 ##### Templates for searching slots in forms
 ```
-curl -L -X POST 'http://localhost:9200/_scripts/form-with-slot' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/form-with-slot.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/form-with-slot' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/form-with-slot.json"
 ```
 ##### Test template
 ```
-curl -L -X GET 'http://localhost:9200/forms/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "form-with-slot", "params": {"slot": "affirm_deny"}}'
+curl -L -X GET '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/forms/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "form-with-slot", "params": {"slot": "affirm_deny"}}'
 ```
 ## Entities
 ##### Create entities index
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/entities" -ku admin:admin --data-binary "@fieldMappings/entities.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/entities" -ku admin:admin --data-binary "@fieldMappings/entities.json"
 ```
 ##### Add mock data from entities.json file
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/entities/_bulk" -ku admin:admin --data-binary "@mock/entities.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/entities/_bulk" -ku admin:admin --data-binary "@mock/entities.json"
 ```
 ##### Test query to index to validate that mock data is there
 ```
-curl -H 'Content-Type: application/json' -X GET "http://localhost:9200/entities/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"entity":"asukoht"}}}'
+curl -H 'Content-Type: application/json' -X GET "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/entities/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"entity":"asukoht"}}}'
 ```
 ##### Templates for searching entities
 ```
-curl -L -X POST 'http://localhost:9200/_scripts/entity-with-name' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/entity-with-name.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/entity-with-name' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/entity-with-name.json"
 ```
 ##### Test template
 ```
-curl -L -X GET 'http://localhost:9200/entities/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "entity-with-name", "params": {"entity": "common_tervitus"}}'
+curl -L -X GET '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/entities/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "entity-with-name", "params": {"entity": "common_tervitus"}}'
 ```
 ##### Templates for searching entities with examples
 ```
-curl -L -X POST 'http://localhost:9200/_scripts/entities-with-examples' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/entities-with-examples.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/entities-with-examples' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/entities-with-examples.json"
 ```
 ##### Test template
 ```
-curl -L -X GET 'http://localhost:9200/entities/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "entities-with-examples", "params": {"entity": "asukoht"}}'
+curl -L -X GET '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/entities/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "entities-with-examples", "params": {"entity": "asukoht"}}'
 ```
 ## Regexes
 ##### Create regexes index
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/regexes" -ku admin:admin --data-binary "@fieldMappings/regexes.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/regexes" -ku admin:admin --data-binary "@fieldMappings/regexes.json"
 ```
 ##### Add mock data from regexes.json file
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/regexes/_bulk" -ku admin:admin --data-binary "@mock/regexes.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/regexes/_bulk" -ku admin:admin --data-binary "@mock/regexes.json"
 ```
 ##### Test query to index to validate that mock data is there
 ```
-curl -H 'Content-Type: application/json' -X GET "http://localhost:9200/regexes/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"regex":"asukoht"}}}'
+curl -H 'Content-Type: application/json' -X GET "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/regexes/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"regex":"asukoht"}}}'
 ```
 ##### Templates for searching regexes
 ```
-curl -L -X POST 'http://localhost:9200/_scripts/regex-with-name' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/regex-with-name.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/regex-with-name' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/regex-with-name.json"
 ```
 ##### Test template
 ```
-curl -L -X GET 'http://localhost:9200/regexes/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "regex-with-name", "params": {"regex": "asukoht"}}'
+curl -L -X GET '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/regexes/_search/template' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-raw '{"id": "regex-with-name", "params": {"regex": "asukoht"}}'
 ```
 ## Examples entities
 ##### Create examples entities index
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/examples-entities" -ku admin:admin --data-binary "@fieldMappings/examples-entities.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/examples-entities" -ku admin:admin --data-binary "@fieldMappings/examples-entities.json"
 ```
 ##### Add mock data from examples-entities.json file
 ```
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/examples-entities/_bulk" -ku admin:admin --data-binary "@mock/examples-entities.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/examples-entities/_bulk" -ku admin:admin --data-binary "@mock/examples-entities.json"
 ```
 ##### Test query to index to validate that mock data is there
 ```
-curl -H 'Content-Type: application/json' -X GET "http://localhost:9200/examples-entities/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"file":"rahvaarv_nlu.yml"}}}'
+curl -H 'Content-Type: application/json' -X GET "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/examples-entities/_search?pretty=true" -ku admin:admin -d' {"query":{"match":{"file":"rahvaarv_nlu.yml"}}}'
 ```

--- a/DSL/OpenSearch/init.sh
+++ b/DSL/OpenSearch/init.sh
@@ -1,53 +1,53 @@
 #clear
-curl -XDELETE 'http://localhost:9200/*' -u admin:admin --insecure
+curl -XDELETE '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/*' -u admin:admin --insecure
 #responses
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/responses" -ku admin:admin --data-binary "@fieldMappings/responses.json"
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/responses/_bulk" -ku admin:admin --data-binary "@mock/responses.json"
-curl -L -X POST 'http://localhost:9200/_scripts/response-with-name-and-text' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/response-with-name-and-text.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/responses" -ku admin:admin --data-binary "@fieldMappings/responses.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/responses/_bulk" -ku admin:admin --data-binary "@mock/responses.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/response-with-name-and-text' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/response-with-name-and-text.json"
 
 #intents
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/intents" -ku admin:admin --data-binary "@fieldMappings/intents.json"
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/intents/_bulk" -ku admin:admin --data-binary "@mock/intents.json"
-curl -L -X POST 'http://localhost:9200/_scripts/intent-with-name' -H 'Content-Type: application/json' --data-binary "@templates/intent-with-name.json"
-curl -L -X POST 'http://localhost:9200/_scripts/intents-with-examples-count' -H 'Content-Type: application/json' --data-binary "@templates/intents-with-examples-count.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/intents" -ku admin:admin --data-binary "@fieldMappings/intents.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/intents/_bulk" -ku admin:admin --data-binary "@mock/intents.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/intent-with-name' -H 'Content-Type: application/json' --data-binary "@templates/intent-with-name.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/intents-with-examples-count' -H 'Content-Type: application/json' --data-binary "@templates/intents-with-examples-count.json"
 
 #rules
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/rules" -ku admin:admin --data-binary "@fieldMappings/rules.json"
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/rules/_bulk" -ku admin:admin --data-binary "@mock/rules.json"
-curl -L -X POST 'http://localhost:9200/_scripts/rule-with-name' -H 'Content-Type: application/json' --data-binary "@templates/rule-with-name.json"
-curl -L -X POST 'http://localhost:9200/_scripts/rule-with-forms' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/rule-with-forms.json"
-curl -L -X POST 'http://localhost:9200/_scripts/rule-with-responses' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/rule-with-responses.json"
-curl -L -X POST 'http://localhost:9200/_scripts/rule-with-slots' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/rule-with-slots.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/rules" -ku admin:admin --data-binary "@fieldMappings/rules.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/rules/_bulk" -ku admin:admin --data-binary "@mock/rules.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/rule-with-name' -H 'Content-Type: application/json' --data-binary "@templates/rule-with-name.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/rule-with-forms' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/rule-with-forms.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/rule-with-responses' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/rule-with-responses.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/rule-with-slots' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/rule-with-slots.json"
 
 #stories
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/stories" -ku admin:admin --data-binary "@fieldMappings/stories.json"
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/stories/_bulk" -ku admin:admin --data-binary "@mock/stories.json"
-curl -L -X POST 'http://localhost:9200/_scripts/story-with-name' -H 'Content-Type: application/json' --data-binary "@templates/story-with-name.json"
-curl -L -X POST 'http://localhost:9200/_scripts/story-with-forms' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/story-with-forms.json"
-curl -L -X POST 'http://localhost:9200/_scripts/story-with-responses' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/story-with-responses.json"
-curl -L -X POST 'http://localhost:9200/_scripts/story-with-slots' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/story-with-slots.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/stories" -ku admin:admin --data-binary "@fieldMappings/stories.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/stories/_bulk" -ku admin:admin --data-binary "@mock/stories.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/story-with-name' -H 'Content-Type: application/json' --data-binary "@templates/story-with-name.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/story-with-forms' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/story-with-forms.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/story-with-responses' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/story-with-responses.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/story-with-slots' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/story-with-slots.json"
 
 #Test stories
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/test-stories" -ku admin:admin --data-binary "@fieldMappings/test-stories.json"
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/test-stories/_bulk" -ku admin:admin --data-binary "@mock/test-stories.json"
-curl -L -X POST 'http://localhost:9200/_scripts/test-story-with-name' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/test-story-with-name.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/test-stories" -ku admin:admin --data-binary "@fieldMappings/test-stories.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/test-stories/_bulk" -ku admin:admin --data-binary "@mock/test-stories.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/test-story-with-name' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/test-story-with-name.json"
 
 #Forms
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/forms" -ku admin:admin --data-binary "@fieldMappings/forms.json"
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/forms/_bulk" -ku admin:admin --data-binary "@mock/forms.json"
-curl -L -X POST 'http://localhost:9200/_scripts/form-with-slot' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/form-with-slot.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/forms" -ku admin:admin --data-binary "@fieldMappings/forms.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/forms/_bulk" -ku admin:admin --data-binary "@mock/forms.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/form-with-slot' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/form-with-slot.json"
 
 #Entities
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/entities" -ku admin:admin --data-binary "@fieldMappings/entities.json"
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/entities/_bulk" -ku admin:admin --data-binary "@mock/entities.json"
-curl -L -X POST 'http://localhost:9200/_scripts/entity-with-name' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/entity-with-name.json"
-curl -L -X POST 'http://localhost:9200/_scripts/entities-with-examples' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/entities-with-examples.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/entities" -ku admin:admin --data-binary "@fieldMappings/entities.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/entities/_bulk" -ku admin:admin --data-binary "@mock/entities.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/entity-with-name' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/entity-with-name.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/entities-with-examples' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/entities-with-examples.json"
 
 #Regexes
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/regexes" -ku admin:admin --data-binary "@fieldMappings/regexes.json"
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/regexes/_bulk" -ku admin:admin --data-binary "@mock/regexes.json"
-curl -L -X POST 'http://localhost:9200/_scripts/regex-with-name' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/regex-with-name.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/regexes" -ku admin:admin --data-binary "@fieldMappings/regexes.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/regexes/_bulk" -ku admin:admin --data-binary "@mock/regexes.json"
+curl -L -X POST '[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/_scripts/regex-with-name' -H 'Content-Type: application/json' -H 'Cookie: customJwtCookie=test' --data-binary "@templates/regex-with-name.json"
 
 #Examples entities
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/examples-entities" -ku admin:admin --data-binary "@fieldMappings/examples-entities.json"
-curl -H "Content-Type: application/x-ndjson" -X PUT "http://localhost:9200/examples-entities/_bulk" -ku admin:admin --data-binary "@mock/examples-entities.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/examples-entities" -ku admin:admin --data-binary "@fieldMappings/examples-entities.json"
+curl -H "Content-Type: application/x-ndjson" -X PUT "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/examples-entities/_bulk" -ku admin:admin --data-binary "@mock/examples-entities.json"

--- a/DSL/Ruuter.private/GET/domain-file.yml
+++ b/DSL/Ruuter.private/GET/domain-file.yml
@@ -16,13 +16,13 @@ validatePermission:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 getDomainFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
   result: domainFile
@@ -30,7 +30,7 @@ getDomainFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json"
     body:
       file: ${domainFile.response.body.file}
   result: domainData

--- a/DSL/Ruuter.private/GET/rasa/config.yml
+++ b/DSL/Ruuter.private/GET/rasa/config.yml
@@ -16,13 +16,13 @@ validatePermission:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 getConfigFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.config_location}
   result: configFile
@@ -30,7 +30,7 @@ getConfigFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json"
     body:
       file: ${configFile.response.body.file}
   result: configData

--- a/DSL/Ruuter.private/GET/rasa/entities.yml
+++ b/DSL/Ruuter.private/GET/rasa/entities.yml
@@ -16,13 +16,13 @@ validatePermission:
 getEntities:
   call: http.get
   args:
-    url: http://host.docker.internal:9200/entities/_search?size=10000
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/entities/_search?size=10000"
   result: getEntitiesResult
 
 mapEntitiesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-entities
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-entities"
     body:
       hits: ${getEntitiesResult.response.body.hits.hits}
   result: entitiesData

--- a/DSL/Ruuter.private/GET/rasa/forms.yml
+++ b/DSL/Ruuter.private/GET/rasa/forms.yml
@@ -16,13 +16,13 @@ validatePermission:
 getForms:
   call: http.get
   args:
-    url: http://host.docker.internal:9200/forms/_search?size=10000
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/forms/_search?size=10000"
   result: getFormsResult
 
 mapFormsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-forms
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-forms"
     body:
       hits: ${getFormsResult.response.body.hits.hits}
   result: formsData

--- a/DSL/Ruuter.private/GET/rasa/intents.yml
+++ b/DSL/Ruuter.private/GET/rasa/intents.yml
@@ -16,13 +16,13 @@ validatePermission:
 getIntents:
   call: http.get
   args:
-    url: http://host.docker.internal:9200/intents/_search?size=10000
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/intents/_search?size=10000"
   result: getIntentsResult
 
 mapIntentsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-intents
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-intents"
     body:
       hits: ${getIntentsResult.response.body.hits.hits}
   result: intentsData

--- a/DSL/Ruuter.private/GET/rasa/intents/examples/count.yml
+++ b/DSL/Ruuter.private/GET/rasa/intents/examples/count.yml
@@ -16,7 +16,7 @@ validatePermission:
 getIntentsExampleCount:
   call: http.post
   args:
-    url: http://localhost:9200/intents/_search/template
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/intents/_search/template"
     body:
       id: "intents-with-examples-count"
       params:
@@ -26,7 +26,7 @@ getIntentsExampleCount:
 mapIntentsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-intents-with-examples-count
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-intents-with-examples-count
     body:
       buckets: ${getIntentsResult.response.body.aggregations.hot.buckets}
   result: intentsData

--- a/DSL/Ruuter.private/GET/rasa/intents/in-model.yml
+++ b/DSL/Ruuter.private/GET/rasa/intents/in-model.yml
@@ -16,7 +16,7 @@ validatePermission:
 getDomainFile:
   call: http.get
   args:
-    url: http://localhost:8080/domain-file
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${cookie}
   result: domainData

--- a/DSL/Ruuter.private/GET/rasa/regexes.yml
+++ b/DSL/Ruuter.private/GET/rasa/regexes.yml
@@ -16,13 +16,13 @@ validatePermission:
 getRegexes:
   call: http.get
   args:
-    url: http://host.docker.internal:9200/regexes/_search?size=10000
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/regexes/_search?size=10000"
   result: getRegexesResult
 
 mapRegexesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-regexes
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-regexes"
     body:
       hits: ${getRegexesResult.response.body.hits.hits}
   result: regexesData

--- a/DSL/Ruuter.private/GET/rasa/responses.yml
+++ b/DSL/Ruuter.private/GET/rasa/responses.yml
@@ -1,13 +1,13 @@
 getResponses:
   call: http.get
   args:
-    url: http://host.docker.internal:9200/responses/_search?size=10000
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/responses/_search?size=10000"
   result: getResponsesResult
 
 #mapResponsesData:
 #  call: http.post
 #  args:
-#    url: http://host.docker.internal:3000/dmapper/get-responses
+#    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-responses"
 #    body:
 #      hits: ${getResponsesResult.response.body.hits.hits}
 #  result: responsesData

--- a/DSL/Ruuter.private/GET/rasa/responses/dependencies.yml
+++ b/DSL/Ruuter.private/GET/rasa/responses/dependencies.yml
@@ -16,13 +16,13 @@ validatePermission:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 getRulesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.rules_location}
   result: ruleFile
@@ -30,7 +30,7 @@ getRulesFile:
 getRulesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${ruleFile.response.body.file}
   result: rulesData
@@ -38,7 +38,7 @@ getRulesData:
 getStoriesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.stories_location}
   result: storiesFile
@@ -46,7 +46,7 @@ getStoriesFile:
 getStoriesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${storiesFile.response.body.file}
   result: storiesData
@@ -54,13 +54,13 @@ getStoriesData:
 getResponses:
   call: http.get
   args:
-    url: http://host.docker.internal:9200/responses/_search?size=10000
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/responses/_search?size=10000"
   result: getResponsesResult
 
 mapDependenciesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-responses-dependencies
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-responses-dependencies
     body:
       rules: ${rulesData.response.body.rules}
       stories: ${storiesData.response.body.stories}

--- a/DSL/Ruuter.private/GET/rasa/rules.yml
+++ b/DSL/Ruuter.private/GET/rasa/rules.yml
@@ -16,13 +16,13 @@ validatePermission:
 getRules:
   call: http.get
   args:
-    url: http://host.docker.internal:9200/rules/_search?size=10000
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/rules/_search?size=10000"
   result: getRulesResult
 
 mapRulesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-rules
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-rules"
     body:
       hits: ${getRulesResult.response.body.hits.hits}
   result: rulesData

--- a/DSL/Ruuter.private/GET/rasa/slots.yml
+++ b/DSL/Ruuter.private/GET/rasa/slots.yml
@@ -16,13 +16,13 @@ validatePermission:
 getSlots:
   call: http.get
   args:
-    url: http://host.docker.internal:9200/slots/_search?size=10000
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/slots/_search?size=10000"
   result: getSlotsResult
 
 mapSlotsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-slots
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-slots"
     body:
       hits: ${getSlotsResult.response.body.hits.hits}
   result: slotsData

--- a/DSL/Ruuter.private/GET/rasa/stories.yml
+++ b/DSL/Ruuter.private/GET/rasa/stories.yml
@@ -16,13 +16,13 @@ validatePermission:
 getStories:
   call: http.get
   args:
-    url: http://host.docker.internal:9200/stories/_search?size=10000
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/stories/_search?size=10000"
   result: getStoriesResult
 
 mapStoriesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-stories
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-stories"
     body:
       hits: ${getStoriesResult.response.body.hits.hits}
   result: storiesData

--- a/DSL/Ruuter.private/GET/rasa/test-stories.yml
+++ b/DSL/Ruuter.private/GET/rasa/test-stories.yml
@@ -16,13 +16,13 @@ validatePermission:
 getTestStories:
   call: http.get
   args:
-    url: http://host.docker.internal:9200/test-stories/_search?size=10000
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/test-stories/_search?size=10000"
   result: getTestStoriesResult
 
 mapTestStoriesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-test-stories
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-test-stories"
     body:
       hits: ${getTestStoriesResult.response.body.hits.hits}
   result: testStoriesData

--- a/DSL/Ruuter.private/GET/rasa/test-stories/links.yml
+++ b/DSL/Ruuter.private/GET/rasa/test-stories/links.yml
@@ -16,25 +16,25 @@ validatePermission:
 getRules:
   call: http.get
   args:
-    url: http://host.docker.internal:9200/rules/_search?size=10000
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/rules/_search?size=10000"
   result: getRulesResult
 
 getStories:
   call: http.get
   args:
-    url: http://host.docker.internal:9200/stories/_search?size=10000
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/stories/_search?size=10000"
   result: getStoriesResult
 
 getTestStories:
   call: http.get
   args:
-    url: http://host.docker.internal:9200/test-stories/_search?size=10000
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/test-stories/_search?size=10000"
   result: getTestStoriesResult
 
 mapLinksData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-links
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-links
     body:
       rules: ${getRulesResult.response.body.hits.hits}
       stories: ${getStoriesResult.response.body.hits.hits}

--- a/DSL/Ruuter.private/GET/rasa/training/results.yml
+++ b/DSL/Ruuter.private/GET/rasa/training/results.yml
@@ -16,13 +16,13 @@ validatePermission:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 getTrainingResultsDirectory:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read-directory
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read-directory
     body:
       file_path: ${fileLocations.response.body.response.training_result_location}
   result: trainingResults

--- a/DSL/Ruuter.private/POST/csv.yml
+++ b/DSL/Ruuter.private/POST/csv.yml
@@ -7,7 +7,7 @@ check_for_required_parameters:
 get_csv:
   call: http.post
   args:
-    url: http://data_mapper:3005/hbs/training/get-csv
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/hbs/training/get-csv"
     headers:
       type: 'csv'
     body:

--- a/DSL/Ruuter.private/POST/extract-token.yml
+++ b/DSL/Ruuter.private/POST/extract-token.yml
@@ -1,7 +1,7 @@
 extractTokenData:
   call: http.post
   args:
-    url: http://localhost:8080/mock-tim-custom-jwt-userinfo
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${incoming.headers.cookie}
     body:

--- a/DSL/Ruuter.private/POST/rasa/config/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/config/update.yml
@@ -20,13 +20,13 @@ validatePermission:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml"
     body:
       recipe: ${input.recipe}
       language: ${input.language}
@@ -37,7 +37,7 @@ convertJsonToYaml:
 saveConfigFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.config_location}
       content: ${configYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/entities.yml
+++ b/DSL/Ruuter.private/POST/rasa/entities.yml
@@ -20,7 +20,7 @@ validatePermission:
 getEntitiesWithName:
   call: http.post
   args:
-    url: http://host.docker.internal:9200/entities/_search/template
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/entities/_search/template"
     body:
       id: "entity-with-name"
       params: ${params}
@@ -29,7 +29,7 @@ getEntitiesWithName:
 mapEntitiesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-entity-with-name
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-entity-with-name"
     body:
       hits: ${getEntitiesResult.response.body.hits.hits}
   result: entitiesData

--- a/DSL/Ruuter.private/POST/rasa/entities/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/entities/add.yml
@@ -20,7 +20,7 @@ validatePermission:
 getDomainFile:
   call: http.get
   args:
-    url: http://localhost:8080/domain-file
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${cookie}
   result: domainData
@@ -34,7 +34,7 @@ validateEntities:
 mergeEntities:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge
     body:
       array1: ${domainData.response.body.response.entities}
       array2: ${[parameters.entity]}
@@ -43,7 +43,7 @@ mergeEntities:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -58,13 +58,13 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 saveDomainFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/entities/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/entities/delete.yml
@@ -20,7 +20,7 @@ validatePermission:
 getDomainFile:
   call: http.get
   args:
-    url: http://localhost:8080/domain-file
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${cookie}
   result: domainData
@@ -34,7 +34,7 @@ validateEntities:
 domainEntities:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/entities
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/entities"
     headers:
       cookie: ${cookie}
     body:
@@ -50,7 +50,7 @@ validateDomainEntities:
 regexEntities:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/regex
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/regex"
     headers:
       cookie: ${cookie}
     body:
@@ -67,7 +67,7 @@ validateRegexEntities:
 intentEntities:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/examples/entities
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/examples/entities"
     headers:
       cookie: ${cookie}
     body:
@@ -84,7 +84,7 @@ validateIntentEntities:
 deleteEntity:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/delete-entity
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/delete-entity
     body:
       entities: ${domainData.response.body.response.entities}
       entity_name: ${parameters.entity_name}
@@ -93,7 +93,7 @@ deleteEntity:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -108,13 +108,13 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 saveDomainFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/entities/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/entities/update.yml
@@ -20,7 +20,7 @@ validatePermission:
 getDomainFile:
   call: http.get
   args:
-    url: http://localhost:8080/domain-file
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${cookie}
   result: domainData
@@ -34,7 +34,7 @@ validateEntities:
 replaceExistingEntity:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge/replace-array-element
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge/replace-array-element
     body:
       element: ${parameters.entity_name}
       newValue: ${parameters.entity}
@@ -44,7 +44,7 @@ replaceExistingEntity:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -59,13 +59,13 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 saveDomainFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}
@@ -80,7 +80,7 @@ switchFileType:
 getRegexFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.regex_location}
   result: intentFile
@@ -89,7 +89,7 @@ getRegexFile:
 getIntentFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + "_nlu.yml"}
   result: intentFile
@@ -97,7 +97,7 @@ getIntentFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${intentFile.response.body.file}
   result: intentData
@@ -105,7 +105,7 @@ convertYamlToJson:
 replaceString:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/replace
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/replace
     body:
       data: ${intentData.response.body.nlu[0].examples}
       search: "- "
@@ -115,7 +115,7 @@ replaceString:
 splitExamples:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/split
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/split
     body:
       data: ${replacedString.response.body}
       separator: "\n"
@@ -130,7 +130,7 @@ switchMapFileType:
 mapRegexesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-regex-file
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-regex-file
     body:
       regex: ${parameters.entity}
       examples: ${splitExamples.response.body}
@@ -140,7 +140,7 @@ mapRegexesData:
 mapIntentsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-intent-file
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-intent-file
     body:
       intent: ${parameters.entity}
       examples: ${splitExamples.response.body}
@@ -149,7 +149,7 @@ mapIntentsData:
 convertIntentJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: "3.0"
       nlu: ${intentFileJson.response.body}
@@ -164,7 +164,7 @@ switchSaveFileType:
 saveRegexFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.regex_location}
       content: ${intentYaml.response.body.json}
@@ -174,7 +174,7 @@ saveRegexFile:
 saveIntentFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + "_nlu.yml"}
       content: ${intentYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/examples/entities.yml
+++ b/DSL/Ruuter.private/POST/rasa/examples/entities.yml
@@ -20,7 +20,7 @@ validatePermission:
 getEntitiesWithExamples:
   call: http.post
   args:
-    url: http://host.docker.internal:9200/examples-entities/_search/template
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/examples-entities/_search/template"
     body:
       id: "entities-with-examples"
       params: ${params}
@@ -29,7 +29,7 @@ getEntitiesWithExamples:
 mapEntitiesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-entities-with-examples
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-entities-with-examples
     body:
       hits: ${getEntitiesResult.response.body.hits.hits}
       examples: ${params.examples}

--- a/DSL/Ruuter.private/POST/rasa/forms/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/forms/add.yml
@@ -20,7 +20,7 @@ validatePermission:
 getDomainFile:
   call: http.get
   args:
-    url: http://localhost:8080/domain-file
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${cookie}
   result: domainData
@@ -34,7 +34,7 @@ validateForms:
 mergeForms:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge/objects
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge/objects"
     body:
       object1: ${domainData.response.body.response.forms}
       object2: ${parameters.form}
@@ -43,7 +43,7 @@ mergeForms:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml"
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -58,13 +58,13 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 saveDomainFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/forms/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/forms/delete.yml
@@ -20,7 +20,7 @@ validatePermission:
 getDomainFile:
   call: http.get
   args:
-    url: http://localhost:8080/domain-file
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${cookie}
   result: domainData
@@ -34,7 +34,7 @@ validateForms:
 ruleForms:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/rules/search
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules/search"
     headers:
       cookie: ${cookie}
     body:
@@ -51,7 +51,7 @@ validateRuleForms:
 storiesForms:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/stories/search
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories/search"
     headers:
       cookie: ${cookie}
     body:
@@ -68,7 +68,7 @@ validateStoriesSlots:
 deleteKey:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge/remove-key
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge/remove-key"
     body:
       object: ${domainData.response.body.response.forms}
       key: ${parameters.form_name}
@@ -77,7 +77,7 @@ deleteKey:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml"
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -92,13 +92,13 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 saveDomainFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/forms/search.yml
+++ b/DSL/Ruuter.private/POST/rasa/forms/search.yml
@@ -20,7 +20,7 @@ validatePermission:
 getFormsSlots:
   call: http.post
   args:
-    url: http://host.docker.internal:9200/forms/_search/template
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/forms/_search/template"
     body:
       id: "form-with-slot"
       params: ${params}
@@ -29,7 +29,7 @@ getFormsSlots:
 mapFormsSlotsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-forms-search-slots
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-forms-search-slots"
     body:
       hits: ${getFormsResultSlots.response.body.hits.hits}
   result: formsData

--- a/DSL/Ruuter.private/POST/rasa/forms/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/forms/update.yml
@@ -20,7 +20,7 @@ validatePermission:
 getDomainFile:
   call: http.get
   args:
-    url: http://localhost:8080/domain-file
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${cookie}
   result: domainData
@@ -34,7 +34,7 @@ validateForms:
 mergeForms:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge/objects
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge/objects"
     body:
       object1: ${domainData.response.body.response.forms}
       object2: ${parameters.form}
@@ -43,7 +43,7 @@ mergeForms:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml"
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -58,13 +58,13 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 saveDomainFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/intents.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents.yml
@@ -20,7 +20,7 @@ validatePermission:
 getIntentsWithName:
   call: http.post
   args:
-    url: http://host.docker.internal:9200/intents/_search/template
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/intents/_search/template"
     body:
       id: "intent-with-name"
       params: ${params}
@@ -30,7 +30,7 @@ getIntentsWithName:
 mapIntentsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-intent-with-name
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-intent-with-name"
     body:
       hits: ${getIntentsResult.response.body.hits.hits}
   result: intentsData

--- a/DSL/Ruuter.private/POST/rasa/intents/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/add.yml
@@ -26,7 +26,7 @@ validateInputLength:
 getDomainFile:
   call: http.get
   args:
-    url: http://localhost:8080/domain-file
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -40,13 +40,13 @@ validateIntentExists:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 mapIntentsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-intent-file
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-intent-file"
     body:
       intent: ${intent}
   result: intentFileJson
@@ -54,7 +54,7 @@ mapIntentsData:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml"
     body:
       version: "3.0"
       nlu: ${intentFileJson.response.body}
@@ -63,7 +63,7 @@ convertJsonToYaml:
 saveIntentFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.intents_location + intent + "_nlu.yml.tmp"}
       content: ${intentYaml.response.body.json}
@@ -72,7 +72,7 @@ saveIntentFile:
 mergeIntents:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge"
     body:
       array1: ${[intent]}
       array2: ${domainData.response.body.response.intents}
@@ -81,7 +81,7 @@ mergeIntents:
 convertDomainJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: ${domainData.response.body.response.version}
       intents: ${mergedIntents.response.body}
@@ -96,7 +96,7 @@ convertDomainJsonToYaml:
 saveDomainFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/intents/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/delete.yml
@@ -20,7 +20,7 @@ validatePermission:
 getDomainFile:
   call: http.get
   args:
-    url: http://localhost:8080/domain-file
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -34,7 +34,7 @@ validateIntentExists:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 assignFilePath:
@@ -44,7 +44,7 @@ assignFilePath:
 checkIntentFileYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/check
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/check"
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
   result: fileExists
@@ -62,7 +62,7 @@ assignTmpFilePath:
 checkIntentFileTmp:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/check
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/check"
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
   result: tmpFileExists
@@ -76,7 +76,7 @@ validateTmpFileExists:
 getRulesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.rules_location}
   result: ruleFile
@@ -84,7 +84,7 @@ getRulesFile:
 convertRulesYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json"
     body:
       file: ${ruleFile.response.body.file}
   result: rulesData
@@ -92,7 +92,7 @@ convertRulesYamlToJson:
 convertRulesJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: "3.0"
       rules: ${rulesData.response.body.rules}
@@ -107,7 +107,7 @@ validateRuleDependency:
 getStoriesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.stories_location}
   result: storiesFile
@@ -115,7 +115,7 @@ getStoriesFile:
 convertStoriesYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${storiesFile.response.body.file}
   result: storiesData
@@ -123,7 +123,7 @@ convertStoriesYamlToJson:
 convertStoriesJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: "3.0"
       stories: ${storiesData.response.body.stories}
@@ -138,7 +138,7 @@ validateStoriesDependency:
 getIntentFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
   result: intentFile
@@ -146,7 +146,7 @@ getIntentFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${intentFile.response.body.file}
   result: intentData
@@ -154,7 +154,7 @@ convertYamlToJson:
 replaceString:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/replace
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/replace
     body:
       data: ${intentData.response.body.nlu[0].examples}
       search: "- "
@@ -164,7 +164,7 @@ replaceString:
 splitExamples:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/split
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/split
     body:
       data: ${replacedString.response.body}
       separator: "\n"
@@ -173,7 +173,7 @@ splitExamples:
 mapIntentsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-intent-file
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-intent-file
     body:
       intent: ${parameters.intent}
       examples: ${splitExamples.response.body}
@@ -182,7 +182,7 @@ mapIntentsData:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: "3.0"
       nlu: ${intentFileJson.response.body}
@@ -191,7 +191,7 @@ convertJsonToYaml:
 saveIntentFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.intents_location + "removed/" + parameters.intent + file_end}
       content: ${intentYaml.response.body.json}
@@ -200,7 +200,7 @@ saveIntentFile:
 deleteOldIntentFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/delete
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/delete
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
   result: deleted
@@ -208,7 +208,7 @@ deleteOldIntentFile:
 deleteExistingIntent:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge/remove-array-value
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge/remove-array-value
     body:
       array: ${domainData.response.body.response.intents}
       value: ${parameters.intent}
@@ -217,7 +217,7 @@ deleteExistingIntent:
 convertDomainJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: ${domainData.response.body.response.version}
       intents: ${updatedIntents.response.body}
@@ -232,7 +232,7 @@ convertDomainJsonToYaml:
 saveDomainFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/intents/download.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/download.yml
@@ -20,7 +20,7 @@ validatePermission:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 assignFilePath:
@@ -30,7 +30,7 @@ assignFilePath:
 checkIntentFileYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/check
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/check"
     body:
       file_path: ${fileLocations.response.body.response.intents_location + intent + file_end}
   result: fileExists
@@ -48,7 +48,7 @@ assignTmpFilePath:
 checkIntentFileTmp:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/check
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/check"
     body:
       file_path: ${fileLocations.response.body.response.intents_location + intent + file_end}
   result: tmpFileExists
@@ -62,7 +62,7 @@ validateTmpFileExists:
 getIntentFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.intents_location + intent + file_end}
   result: intentFile
@@ -70,7 +70,7 @@ getIntentFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json"
     body:
       file: ${intentFile.response.body.file}
   result: intentData
@@ -78,7 +78,7 @@ convertYamlToJson:
 replaceString:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/replace
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/replace
     body:
       data: ${intentData.response.body.nlu[0].examples}
       search: "- "
@@ -88,7 +88,7 @@ replaceString:
 splitExamples:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/split
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/split
     body:
       data: ${replacedString.response.body}
       separator: "\n"
@@ -97,7 +97,7 @@ splitExamples:
 mapIntentsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-intent-csv
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-intent-csv
     headers:
       type: 'csv'
     body:

--- a/DSL/Ruuter.private/POST/rasa/intents/examples.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/examples.yml
@@ -20,7 +20,7 @@ validatePermission:
 getIntentsWithName:
   call: http.post
   args:
-    url: http://host.docker.internal:9200/intents/_search/template
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/intents/_search/template"
     body:
       id: "intent-with-name"
       params: ${params}
@@ -30,7 +30,7 @@ getIntentsWithName:
 mapIntentsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-examples
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-examples"
     body:
       hits: ${getIntentsResult.response.body.hits.hits}
   result: intentsData

--- a/DSL/Ruuter.private/POST/rasa/intents/examples/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/examples/add.yml
@@ -20,7 +20,7 @@ validatePermission:
 validateArrayExampleLength:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/validate/array-elements-length
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/validate/array-elements-length
     body:
       array: ${parameters.examples}
       length: 500
@@ -35,7 +35,7 @@ validateLength:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 assignFilePath:
@@ -45,7 +45,7 @@ assignFilePath:
 checkIntentFileYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/check
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/check
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
   result: fileExists
@@ -63,7 +63,7 @@ assignTmpFilePath:
 checkIntentFileTmp:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/check
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/check
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
   result: tmpFileExists
@@ -77,7 +77,7 @@ validateTmpFileExists:
 getIntentFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
   result: intentFile
@@ -85,7 +85,7 @@ getIntentFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${intentFile.response.body.file}
   result: intentData
@@ -93,7 +93,7 @@ convertYamlToJson:
 replaceString:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/replace
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/replace
     body:
       data: ${intentData.response.body.nlu[0].examples}
       search: "- "
@@ -103,7 +103,7 @@ replaceString:
 splitExamples:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/split
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/split
     body:
       data: ${replacedString.response.body}
       separator: "\n"
@@ -112,7 +112,7 @@ splitExamples:
 mergeExamples:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge
     body:
       array1: ${parameters.examples}
       array2: ${splitExamples.response.body}
@@ -127,7 +127,7 @@ validateMinimumExampleCount:
 mapIntentsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-intent-file
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-intent-file
     body:
       intent: ${parameters.intent}
       examples: ${mergedExamples.response.body}
@@ -136,7 +136,7 @@ mapIntentsData:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: "3.0"
       nlu: ${intentFileJson.response.body}
@@ -145,7 +145,7 @@ convertJsonToYaml:
 saveIntentFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
       content: ${intentYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/intents/examples/count.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/examples/count.yml
@@ -20,7 +20,7 @@ validatePermission:
 getIntentsExampleCount:
   call: http.post
   args:
-    url: http://host.docker.internal:9200/intents/_search/template
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/intents/_search/template"
     body:
       id: "intents-with-examples-count"
       params: ${params}
@@ -29,7 +29,7 @@ getIntentsExampleCount:
 mapIntentsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-intents-with-examples-count
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-intents-with-examples-count
     body:
       buckets: ${getIntentsResult.response.body.aggregations.hot.buckets}
   result: intentsData

--- a/DSL/Ruuter.private/POST/rasa/intents/examples/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/examples/delete.yml
@@ -21,7 +21,7 @@ validatePermission:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 assignFilePath:
@@ -31,7 +31,7 @@ assignFilePath:
 checkIntentFileYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/check
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/check
     body:
       file_path: ${fileLocations.response.body.response.intents_location + intent + file_end}
   result: fileExists
@@ -49,7 +49,7 @@ assignTmpFilePath:
 checkIntentFileTmp:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/check
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/check
     body:
       file_path: ${fileLocations.response.body.response.intents_location + intent + file_end}
   result: tmpFileExists
@@ -63,7 +63,7 @@ validateTmpFileExists:
 getIntentFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.intents_location + intent + file_end}
   result: intentFile
@@ -71,7 +71,7 @@ getIntentFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${intentFile.response.body.file}
   result: intentData
@@ -79,7 +79,7 @@ convertYamlToJson:
 replaceString:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/replace
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/replace
     body:
       data: ${intentData.response.body.nlu[0].examples}
       search: "- "
@@ -89,7 +89,7 @@ replaceString:
 splitExamples:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/split
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/split
     body:
       data: ${replacedString.response.body}
       separator: "\n"
@@ -104,7 +104,7 @@ validateExample:
 deleteExistingExample:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge/remove-array-value
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge/remove-array-value
     body:
       array: ${splitExamples.response.body}
       value: ${example}
@@ -113,7 +113,7 @@ deleteExistingExample:
 mapIntentsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-intent-file
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-intent-file
     body:
       intent: ${intent}
       examples: ${updatedExamples.response.body}
@@ -122,7 +122,7 @@ mapIntentsData:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: "3.0"
       nlu: ${intentFileJson.response.body}
@@ -131,7 +131,7 @@ convertJsonToYaml:
 saveIntentFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.intents_location + intent + file_end}
       content: ${intentYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/intents/examples/list.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/examples/list.yml
@@ -20,7 +20,7 @@ validatePermission:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 assignFilePath:
@@ -30,7 +30,7 @@ assignFilePath:
 checkIntentFileYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/check
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/check
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
   result: fileExists
@@ -48,7 +48,7 @@ assignTmpFilePath:
 checkIntentFileTmp:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/check
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/check
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
   result: tmpFileExists
@@ -62,7 +62,7 @@ validateTmpFileExists:
 getIntentFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
   result: intentFile
@@ -70,7 +70,7 @@ getIntentFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${intentFile.response.body.file}
   result: intentData
@@ -78,7 +78,7 @@ convertYamlToJson:
 replaceString:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/replace
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/replace
     body:
       data: ${intentData.response.body.nlu[0].examples}
       search: "- "
@@ -88,7 +88,7 @@ replaceString:
 splitExamples:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/split
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/split
     body:
       data: ${replacedString.response.body}
       separator: "\n"
@@ -97,7 +97,7 @@ splitExamples:
 mapIntentsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-intent-examples
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-intent-examples
     body:
       intent: ${parameters.intent}
       examples: ${splitExamples.response.body}

--- a/DSL/Ruuter.private/POST/rasa/intents/examples/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/examples/update.yml
@@ -20,7 +20,7 @@ validatePermission:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 assignFilePath:
@@ -30,7 +30,7 @@ assignFilePath:
 checkIntentFileYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/check
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/check
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
   result: fileExists
@@ -48,7 +48,7 @@ assignTmpFilePath:
 checkIntentFileTmp:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/check
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/check
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
   result: tmpFileExists
@@ -62,7 +62,7 @@ validateTmpFileExists:
 getIntentFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
   result: intentFile
@@ -70,7 +70,7 @@ getIntentFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${intentFile.response.body.file}
   result: intentData
@@ -78,7 +78,7 @@ convertYamlToJson:
 replaceString:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/replace
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/replace
     body:
       data: ${intentData.response.body.nlu[0].examples}
       search: "- "
@@ -88,7 +88,7 @@ replaceString:
 splitExamples:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/split
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/split
     body:
       data: ${replacedString.response.body}
       separator: "\n"
@@ -105,7 +105,7 @@ validateExample:
 replaceExistingExample:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge/replace-array-element
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge/replace-array-element
     body:
       element: ${parameters.example}
       newValue: ${parameters.new_example}
@@ -115,7 +115,7 @@ replaceExistingExample:
 mapIntentsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-intent-file
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-intent-file
     body:
       intent: ${parameters.intent}
       examples: ${replacedExamples.response.body}
@@ -124,7 +124,7 @@ mapIntentsData:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: "3.0"
       nlu: ${intentFileJson.response.body}
@@ -133,7 +133,7 @@ convertJsonToYaml:
 saveIntentFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
       content: ${intentYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/intents/history/last-modified.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/history/last-modified.yml
@@ -28,7 +28,7 @@ getIntentLastChanged:
 mapIntentsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-intent-last-changed
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-intent-last-changed
     body:
       intent: ${getIntentLastChangedResult.response.body}
   result: intentsData

--- a/DSL/Ruuter.private/POST/rasa/intents/turn-into-service.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/turn-into-service.yml
@@ -8,7 +8,7 @@ assign_values:
 extract_token_data:
   call: http.post
   args:
-    url: http://localhost:8080/mock-tim-custom-jwt-userinfo
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:
@@ -24,7 +24,7 @@ validate_administrator:
 get_domain_file:
   call: http.get
   args:
-    url: http://localhost:8080/domain-file
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${cookie}
   result: domainData
@@ -38,13 +38,13 @@ validate_intent_exists:
 get_file_locations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 get_existing_intent_file:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.intents_location + intentName + "_nlu.yml"}
   result: intentFile
@@ -52,7 +52,7 @@ get_existing_intent_file:
 convert_yaml_to_json:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json"
     body:
       file: ${intentFile.response.body.file}
   result: intentData
@@ -60,7 +60,7 @@ convert_yaml_to_json:
 manipulate_existing_examples:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/replace
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/replace"
     body:
       data: ${intentData.response.body.nlu[0].examples}
       search: "- "
@@ -70,7 +70,7 @@ manipulate_existing_examples:
 split_existing_examles:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/split
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/split"
     body:
       data: ${manipulateExistingExamplesResult.response.body}
       separator: "\n"
@@ -79,7 +79,7 @@ split_existing_examles:
 get_new_service_intent_file:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-intent-file
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-intent-file
     body:
       intent: ${"service_" + intentName}
       examples: ${splitedExamples.response.body}
@@ -88,7 +88,7 @@ get_new_service_intent_file:
 convert_intent_json_to_yaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: "3.0"
       nlu: ${intentFileJson.response.body}
@@ -97,7 +97,7 @@ convert_intent_json_to_yaml:
 save_intent_file:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.intents_location + "service_" + intentName + "_nlu.tmp"}
       content: ${intentYaml.response.body.json}
@@ -106,7 +106,7 @@ save_intent_file:
 delete_old_intent_file:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/delete
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/delete
     body:
       file_path: ${fileLocations.response.body.response.intents_location + intentName + "_nlu.yml"}
   result: deleteResult
@@ -114,7 +114,7 @@ delete_old_intent_file:
 merge_new_intent_into_existing_intents:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge/replace-array-element
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge/replace-array-element
     body:
       array: ${domainData.response.body.response.intents}
       element: ${intentName}
@@ -124,7 +124,7 @@ merge_new_intent_into_existing_intents:
 update_existing_domain_response:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/domain/update-existing-response
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/domain/update-existing-response
     body:
       json: ${domainData.response.body.response.responses}
       searchKey: ${intentName}
@@ -135,7 +135,7 @@ update_existing_domain_response:
 convert_domain_json_to_yaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: ${domainData.response.body.response.version}
       intents: ${mergedIntents.response.body}
@@ -150,7 +150,7 @@ convert_domain_json_to_yaml:
 resave_domain_file:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}
@@ -160,7 +160,7 @@ resave_domain_file:
 get_rules_file:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.rules_location}
   result: ruleFile
@@ -168,7 +168,7 @@ get_rules_file:
 convert_rules_yaml_to_json:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${ruleFile.response.body.file}
   result: rulesData
@@ -176,7 +176,7 @@ convert_rules_yaml_to_json:
 find_rule_by_intent_name:
   call: http.post
   args:
-    url: "http://host.docker.internal:3000/rules/remove-by-intent-name"
+    url: ""[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/rules/remove-by-intent-name"
     body:
       rulesJson: ${rulesData.response.body.rules}
       searchIntentName: ${intentName}
@@ -185,7 +185,7 @@ find_rule_by_intent_name:
 rules_json_to_yaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body: 
       version: "3.0"
       rules: ${rulesResult.response.body}
@@ -194,7 +194,7 @@ rules_json_to_yaml:
 resave_rules_file:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.rules_location}
       content: ${rulesYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/intents/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/update.yml
@@ -26,7 +26,7 @@ validateInputLength:
 getDomainFile:
   call: http.get
   args:
-    url: http://localhost:8080/domain-file
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${cookie}
   result: domainData
@@ -46,7 +46,7 @@ validateIntentExists:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 assignFilePath:
@@ -56,7 +56,7 @@ assignFilePath:
 checkIntentFileYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/check
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/check"
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
   result: fileExists
@@ -70,7 +70,7 @@ validateFileExists:
 getRulesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.rules_location}
   result: rulesFile
@@ -78,7 +78,7 @@ getRulesFile:
 convertRulesYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json"
     body:
       file: ${rulesFile.response.body.file}
   result: rulesData
@@ -86,7 +86,7 @@ convertRulesYamlToJson:
 convertRulesJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml"
     body:
       version: "3.0"
       rules: ${rulesData.response.body.rules}
@@ -95,7 +95,7 @@ convertRulesJsonToYaml:
 updateRules:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/replace
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/replace"
     body:
       data: ${rulesYaml.response.body.json}
       search: ${"intent:" + " " + parameters.intent}
@@ -105,7 +105,7 @@ updateRules:
 saveRulesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.rules_location}
       content: ${updatedRules.response.body}
@@ -115,7 +115,7 @@ saveRulesFile:
 getStoriesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.stories_location}
   result: storiesFile
@@ -123,7 +123,7 @@ getStoriesFile:
 convertStoriesYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${storiesFile.response.body.file}
   result: storiesData
@@ -131,7 +131,7 @@ convertStoriesYamlToJson:
 convertStoriesJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: "3.0"
       stories: ${storiesData.response.body.stories}
@@ -140,7 +140,7 @@ convertStoriesJsonToYaml:
 updateStories:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/replace
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/replace
     body:
       data: ${storiesYaml.response.body.json}
       search: ${"intent:" + " " + parameters.intent}
@@ -150,7 +150,7 @@ updateStories:
 saveStoriesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.stories_location}
       content: ${updatedStories.response.body}
@@ -164,7 +164,7 @@ assignTmpFilePath:
 checkIntentFileTmp:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/check
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/check
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
   result: tmpFileExists
@@ -178,7 +178,7 @@ validateTmpFileExists:
 getIntentFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
   result: intentFile
@@ -186,7 +186,7 @@ getIntentFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${intentFile.response.body.file}
   result: intentData
@@ -194,7 +194,7 @@ convertYamlToJson:
 replaceString:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/replace
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/replace
     body:
       data: ${intentData.response.body.nlu[0].examples}
       search: "- "
@@ -204,7 +204,7 @@ replaceString:
 splitExamples:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/split
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/split
     body:
       data: ${replacedString.response.body}
       separator: "\n"
@@ -213,7 +213,7 @@ splitExamples:
 mapIntentsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-intent-file
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-intent-file
     body:
       intent: ${parameters.intent}
       examples: ${splitExamples.response.body}
@@ -222,7 +222,7 @@ mapIntentsData:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: "3.0"
       nlu: ${intentFileJson.response.body}
@@ -231,7 +231,7 @@ convertJsonToYaml:
 saveIntentFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.new_name + file_end}
       content: ${intentYaml.response.body.json}
@@ -240,7 +240,7 @@ saveIntentFile:
 deleteOldIntentFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/delete
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/delete
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
   result: deleted
@@ -248,7 +248,7 @@ deleteOldIntentFile:
 mergeIntents:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge
     body:
       array1: ${domainData.response.body.response.intents}
       array2: ${[parameters.intent]}
@@ -257,7 +257,7 @@ mergeIntents:
 replaceExistingIntent:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge/replace-array-element
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge/replace-array-element
     body:
       element: ${parameters.intent}
       newValue: ${parameters.new_name}
@@ -267,7 +267,7 @@ replaceExistingIntent:
 convertDomainJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: ${domainData.response.body.response.version}
       intents: ${updatedIntents.response.body}
@@ -282,7 +282,7 @@ convertDomainJsonToYaml:
 saveDomainFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/intents/upload.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/upload.yml
@@ -20,7 +20,7 @@ validatePermission:
 convertCsvToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/csv-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/csv-to-json"
     body:
       file: ${parameters.file}
   result: jsonData
@@ -28,7 +28,7 @@ convertCsvToJson:
 mapCsvToArray:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/csv-examples-to-array
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/csv-examples-to-array
     body:
       examples: ${jsonData.response.body}
   result: examples
@@ -36,7 +36,7 @@ mapCsvToArray:
 addExamples:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/intents/examples/add
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/intents/examples/add"
     headers:
       cookie: ${cookie}
     body:

--- a/DSL/Ruuter.private/POST/rasa/regex.yml
+++ b/DSL/Ruuter.private/POST/rasa/regex.yml
@@ -20,7 +20,7 @@ validatePermission:
 getRegexesWithName:
   call: http.post
   args:
-    url: http://host.docker.internal:9200/regexes/_search/template
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/regexes/_search/template"
     body:
       id: "regex-with-name"
       params: ${params}
@@ -30,7 +30,7 @@ getRegexesWithName:
 mapRegexesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-regex-with-name
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-regex-with-name"
     body:
       hits: ${getRegexesResult.response.body.hits.hits}
       examples: ${params.examples}

--- a/DSL/Ruuter.private/POST/rasa/regex/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/regex/delete.yml
@@ -20,13 +20,13 @@ validatePermission:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 getRegexFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.regex_location}
   result: regexFile
@@ -34,7 +34,7 @@ getRegexFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${regexFile.response.body.file}
   result: regexData
@@ -42,7 +42,7 @@ convertYamlToJson:
 mapRegexesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-regex-with-regex
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-regex-with-regex
     body:
       regexes: ${regexData.response.body.nlu}
       regex_name: ${parameters.regex_name}
@@ -57,7 +57,7 @@ validateRegexExists:
 replaceJsonString:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/replace
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/replace
     body:
       data: ${regexesData.response.body.examples}
       search: "&quot;"
@@ -67,7 +67,7 @@ replaceJsonString:
 replaceString:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/replace
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/replace
     body:
       data: ${replacedJsonString.response.body}
       search: "- "
@@ -77,7 +77,7 @@ replaceString:
 splitExamples:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/split
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/split
     body:
       data: ${replacedString.response.body}
       separator: "\n"
@@ -86,7 +86,7 @@ splitExamples:
 mapExamples:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-regex-with-example
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-regex-with-example
     body:
       examples: ${splitExamples.response.body}
       example_name: ${parameters.example}
@@ -101,7 +101,7 @@ validateExampleExists:
 deleteRegex:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge/remove-array-value
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge/remove-array-value
     body:
       array: ${splitExamples.response.body}
       value: ${parameters.example}
@@ -110,7 +110,7 @@ deleteRegex:
 mapRegexInput:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-regex-file
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-regex-file
     body:
       regex: ${parameters.regex_name}
       examples: ${deletedRegex.response.body}
@@ -119,7 +119,7 @@ mapRegexInput:
 mergeRegexes:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge
     body:
       array1: ${regexData.response.body.nlu}
       array2: ${mappedRegexInput.response.body}
@@ -129,7 +129,7 @@ mergeRegexes:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: "3.0"
       nlu: ${mergedRegexes.response.body}
@@ -138,7 +138,7 @@ convertJsonToYaml:
 saveRegexFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.regex_location}
       content: ${regexYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/regex/example.yml
+++ b/DSL/Ruuter.private/POST/rasa/regex/example.yml
@@ -20,13 +20,13 @@ validatePermission:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 getRegexFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.regex_location}
   result: regexFile
@@ -34,7 +34,7 @@ getRegexFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json"
     body:
       file: ${regexFile.response.body.file}
   result: regexData
@@ -42,7 +42,7 @@ convertYamlToJson:
 mapRegexesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-regex-with-regex
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-regex-with-regex"
     body:
       regexes: ${regexData.response.body.nlu}
       regex_name: ${parameters.regex_name}
@@ -51,7 +51,7 @@ mapRegexesData:
 replaceJsonString:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/replace
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/replace"
     body:
       data: ${regexesData.response.body.examples}
       search: "&quot;"
@@ -61,7 +61,7 @@ replaceJsonString:
 replaceString:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/replace
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/replace"
     body:
       data: ${replacedJsonString.response.body}
       search: "- "
@@ -71,7 +71,7 @@ replaceString:
 splitExamples:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/string/split
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/string/split"
     body:
       data: ${replacedString.response.body}
       separator: "\n"
@@ -80,7 +80,7 @@ splitExamples:
 mapExamples:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-regex-with-example
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-regex-with-example"
     body:
       examples: ${splitExamples.response.body}
       example_name: ${parameters.example}

--- a/DSL/Ruuter.private/POST/rasa/regex/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/regex/update.yml
@@ -20,13 +20,13 @@ validatePermission:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 getRegexFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.regex_location}
   result: regexFile
@@ -34,7 +34,7 @@ getRegexFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json"
     body:
       file: ${regexFile.response.body.file}
   result: regexData
@@ -42,7 +42,7 @@ convertYamlToJson:
 mapRegexesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-regex-with-regex
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-regex-with-regex"
     body:
       regexes: ${regexData.response.body.nlu}
       regex_name: ${parameters.regex_name}
@@ -57,7 +57,7 @@ validateRegexExists:
 mapRegexInput:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-regex-file
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-regex-file"
     body:
       regex: ${parameters.input.regex}
       examples: ${parameters.input.examples}
@@ -66,7 +66,7 @@ mapRegexInput:
 mergeRegexes:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge"
     body:
       array1: ${regexData.response.body.nlu}
       array2: ${mappedRegexInput.response.body}
@@ -76,7 +76,7 @@ mergeRegexes:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml"
     body:
       version: "3.0"
       nlu: ${mergedRegexes.response.body}
@@ -85,7 +85,7 @@ convertJsonToYaml:
 saveRegexFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.regex_location}
       content: ${regexYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/responses.yml
+++ b/DSL/Ruuter.private/POST/rasa/responses.yml
@@ -20,7 +20,7 @@ validatePermission:
 getResponsesWithNameAndText:
   call: http.post
   args:
-    url: http://host.docker.internal:9200/responses/_search/template
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/responses/_search/template"
     body:
       id: "response-with-name-and-text"
       params: ${params}
@@ -30,7 +30,7 @@ getResponsesWithNameAndText:
 mapResponsesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-responses
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-responses"
     body:
       hits: ${getResponsesResult.response.body.hits.hits}
   result: responsesData

--- a/DSL/Ruuter.private/POST/rasa/responses/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/responses/add.yml
@@ -20,7 +20,7 @@ validatePermission:
 getDomainFile:
   call: http.get
   args:
-    url: http://localhost:8080/domain-file
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -36,7 +36,7 @@ validateResponse:
 mergeResponses:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge/objects
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge/objects
     body:
       object1: ${domainData.response.body.response.responses}
       object2: ${parameters.response}
@@ -45,7 +45,7 @@ mergeResponses:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -60,13 +60,13 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 saveDomainFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/responses/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/responses/delete.yml
@@ -20,7 +20,7 @@ validatePermission:
 getDomainFile:
   call: http.get
   args:
-    url: http://localhost:8080/domain-file
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -34,7 +34,7 @@ validateResponse:
 ruleResponses:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/rules/search
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules/search"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -51,7 +51,7 @@ validateRuleResponses:
 storiesResponses:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/stories/search
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories/search"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -68,7 +68,7 @@ validateStoriesResponses:
 deleteKey:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge/remove-key
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge/remove-key
     body:
       object: ${domainData.response.body.response.responses}
       key: ${parameters.response_name}
@@ -77,7 +77,7 @@ deleteKey:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -92,13 +92,13 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 saveDomainFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/responses/dependencies.yml
+++ b/DSL/Ruuter.private/POST/rasa/responses/dependencies.yml
@@ -20,7 +20,7 @@ validatePermission:
 getResponsesWithNameAndText:
   call: http.post
   args:
-    url: http://host.docker.internal:9200/responses/_search/template
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/responses/_search/template"
     body:
       id: "response-with-name-and-text"
       params: ${params}
@@ -35,7 +35,7 @@ validateResponse:
 ruleResponses:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/rules/search
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules/search"
     headers:
       cookie: ${cookie}
     body:
@@ -46,7 +46,7 @@ ruleResponses:
 storiesResponses:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/stories/search
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories/search"
     headers:
       cookie: ${cookie}
     body:
@@ -57,7 +57,7 @@ storiesResponses:
 mapResponsesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-response-dependencies
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-response-dependencies
     body:
       response: ${getResponsesResult.response.body.hits.hits}
       stories: ${storiesResponses.response.body.response.stories}

--- a/DSL/Ruuter.private/POST/rasa/responses/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/responses/update.yml
@@ -20,7 +20,7 @@ validatePermission:
 getDomainFile:
   call: http.get
   args:
-    url: http://localhost:8080/domain-file
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${cookie}
   result: domainData
@@ -36,7 +36,7 @@ validateResponse:
 mergeResponses:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge/objects
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge/objects
     body:
       object1: ${domainData.response.body.response.responses}
       object2: ${parameters.response}
@@ -45,7 +45,7 @@ mergeResponses:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -60,13 +60,13 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 saveDomainFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/rules.yml
+++ b/DSL/Ruuter.private/POST/rasa/rules.yml
@@ -20,7 +20,7 @@ validatePermission:
 getRulesWithName:
   call: http.post
   args:
-    url: http://host.docker.internal:9200/rules/_search/template
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/rules/_search/template"
     body:
       id: "rule-with-name"
       params: ${params}
@@ -30,7 +30,7 @@ getRulesWithName:
 mapRulesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-rule-with-name
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-rule-with-name"
     body:
       hits: ${getRulesResult.response.body.hits.hits}
   result: rulesData

--- a/DSL/Ruuter.private/POST/rasa/rules/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/rules/add.yml
@@ -21,7 +21,7 @@ validatePermission:
 getRuleWithName:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/rules
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules"
     headers:
       cookie: ${cookie}
     body:
@@ -37,13 +37,13 @@ validateRules:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 getRulesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.rules_location}
   result: ruleFile
@@ -51,7 +51,7 @@ getRulesFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json"
     body:
       file: ${ruleFile.response.body.file}
   result: rulesData
@@ -59,7 +59,7 @@ convertYamlToJson:
 mergeRules:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge"
     body:
       array1: ${rulesData.response.body.rules}
       array2: ${[body]}
@@ -69,7 +69,7 @@ mergeRules:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml"
     body:
       version: "3.0"
       rules: ${mergedRules.response.body}
@@ -78,7 +78,7 @@ convertJsonToYaml:
 saveRulesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.rules_location}
       content: ${rulesYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/rules/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/rules/delete.yml
@@ -21,7 +21,7 @@ validatePermission:
 getRuleWithName:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/rules
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules"
     headers:
       cookie: ${cookie}
     body:
@@ -37,13 +37,13 @@ validateRules:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 getRulesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.rules_location}
   result: ruleFile
@@ -51,7 +51,7 @@ getRulesFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json"
     body:
       file: ${ruleFile.response.body.file}
   result: rulesData
@@ -59,7 +59,7 @@ convertYamlToJson:
 deleteRule:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/delete-rule
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/delete-rule"
     body:
       rules: ${rulesData.response.body.rules}
       rule_name: ${rule}
@@ -68,7 +68,7 @@ deleteRule:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml"
     body:
       version: "3.0"
       rules: ${deleteRulesData.response.body}
@@ -77,7 +77,7 @@ convertJsonToYaml:
 saveRulesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.rules_location}
       content: ${rulesYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/rules/search.yml
+++ b/DSL/Ruuter.private/POST/rasa/rules/search.yml
@@ -20,7 +20,7 @@ validatePermission:
 getRulesSearch:
   call: http.post
   args:
-    url: http://host.docker.internal:9200/rules/_search/template
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/rules/_search/template"
     body:
       id: ${"rule-with-"+params.type}
       params: ${params}
@@ -29,7 +29,7 @@ getRulesSearch:
 mapRulesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-rules
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-rules"
     body:
       hits: ${getRulesResult.response.body.hits.hits}
   result: rulesData

--- a/DSL/Ruuter.private/POST/rasa/rules/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/rules/update.yml
@@ -20,7 +20,7 @@ validatePermission:
 getRuleWithName:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/rules
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules"
     headers:
       cookie: ${cookie}
     body:
@@ -36,13 +36,13 @@ validateRules:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 getRulesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.rules_location}
   result: ruleFile
@@ -50,7 +50,7 @@ getRulesFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json"
     body:
       file: ${ruleFile.response.body.file}
   result: rulesData
@@ -58,7 +58,7 @@ convertYamlToJson:
 mergeRules:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge"
     body:
       array1: ${rulesData.response.body.rules}
       array2: ${[body]}
@@ -68,7 +68,7 @@ mergeRules:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml"
     body:
       version: "3.0"
       rules: ${mergedRules.response.body}
@@ -77,7 +77,7 @@ convertJsonToYaml:
 saveRulesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.rules_location}
       content: ${rulesYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/slots/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/slots/add.yml
@@ -20,7 +20,7 @@ validatePermission:
 getDomainFile:
   call: http.get
   args:
-    url: http://localhost:8080/domain-file
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${cookie}
   result: domainData
@@ -34,7 +34,7 @@ validateSlots:
 mergeSlots:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge/objects
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge/objects"
     body:
       object1: ${domainData.response.body.response.slots}
       object2: ${parameters.slot}
@@ -43,7 +43,7 @@ mergeSlots:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml"
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -58,13 +58,13 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 saveDomainFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/slots/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/slots/delete.yml
@@ -20,7 +20,7 @@ validatePermission:
 getDomainFile:
   call: http.get
   args:
-    url: http://localhost:8080/domain-file
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${cookie}
   result: domainData
@@ -34,7 +34,7 @@ validateSlots:
 formSlots:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/forms/search
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/forms/search"
     headers:
       cookie: ${cookie}
     body:
@@ -50,7 +50,7 @@ validateFormSlots:
 ruleSlots:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/rules/search
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules/search"
     headers:
       cookie: ${cookie}
     body:
@@ -67,7 +67,7 @@ validateRuleSlots:
 storiesSlots:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/stories/search
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories/search"
     headers:
       cookie: ${cookie}
     body:
@@ -84,7 +84,7 @@ validateStoriesSlots:
 deleteKey:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge/remove-key
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge/remove-key"
     body:
       object: ${domainData.response.body.response.slots}
       key: ${parameters.slot_name}
@@ -93,7 +93,7 @@ deleteKey:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml"
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -108,13 +108,13 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 saveDomainFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/slots/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/slots/update.yml
@@ -20,7 +20,7 @@ validatePermission:
 getDomainFile:
   call: http.get
   args:
-    url: http://localhost:8080/domain-file
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${cookie}
   result: domainData
@@ -34,7 +34,7 @@ validateSlots:
 mergeSlots:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge/objects
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge/objects"
     body:
       object1: ${domainData.response.body.response.slots}
       object2: ${parameters.slot}
@@ -43,7 +43,7 @@ mergeSlots:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml"
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -58,13 +58,13 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 saveDomainFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/stories.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories.yml
@@ -20,7 +20,7 @@ validatePermission:
 getStoriesWithName:
   call: http.post
   args:
-    url: http://host.docker.internal:9200/stories/_search/template
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/stories/_search/template"
     body:
       id: "story-with-name"
       params: ${params}
@@ -29,7 +29,7 @@ getStoriesWithName:
 mapStoriesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-story-with-name
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-story-with-name"
     body:
       hits: ${getStoriesResult.response.body.hits.hits}
   result: storiesData

--- a/DSL/Ruuter.private/POST/rasa/stories/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/add.yml
@@ -20,7 +20,7 @@ validatePermission:
 getStoriesWithName:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/stories
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories"
     headers:
       cookie: ${cookie}
     body:
@@ -36,13 +36,13 @@ validateStories:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 getStoriesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.stories_location}
   result: storiesFile
@@ -50,7 +50,7 @@ getStoriesFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json"
     body:
       file: ${storiesFile.response.body.file}
   result: storiesData
@@ -58,7 +58,7 @@ convertYamlToJson:
 mergeStories:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge"
     body:
       array1: ${storiesData.response.body.stories}
       array2: ${[body]}
@@ -68,7 +68,7 @@ mergeStories:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: "3.0"
       stories: ${mergedStories.response.body}
@@ -77,7 +77,7 @@ convertJsonToYaml:
 saveStoriesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.stories_location}
       content: ${storiesYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/stories/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/delete.yml
@@ -20,7 +20,7 @@ validatePermission:
 getStoriesWithName:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/stories
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories"
     headers:
       cookie: ${cookie}
     body:
@@ -36,13 +36,13 @@ validateStories:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 getStoriesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.stories_location}
   result: storiesFile
@@ -50,7 +50,7 @@ getStoriesFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${storiesFile.response.body.file}
   result: storiesData
@@ -58,7 +58,7 @@ convertYamlToJson:
 deleteStory:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/delete-story
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/delete-story
     body:
       stories: ${storiesData.response.body.stories}
       story_name: ${story}
@@ -67,7 +67,7 @@ deleteStory:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: "3.0"
       stories: ${deleteStoriesData.response.body}
@@ -76,7 +76,7 @@ convertJsonToYaml:
 saveStoriesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.stories_location}
       content: ${storiesYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/stories/search.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/search.yml
@@ -20,7 +20,7 @@ validatePermission:
 getStoriesSearch:
   call: http.post
   args:
-    url: http://host.docker.internal:9200/stories/_search/template
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/stories/_search/template"
     body:
       id: ${"story-with-"+params.type}
       params: ${params}
@@ -29,7 +29,7 @@ getStoriesSearch:
 mapStoriesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-stories
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-stories"
     body:
       hits: ${getStoriesResult.response.body.hits.hits}
   result: storiesData

--- a/DSL/Ruuter.private/POST/rasa/stories/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/update.yml
@@ -20,7 +20,7 @@ validatePermission:
 getStoriesWithName:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/stories
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories"
     headers:
       cookie: ${cookie}
     body:
@@ -36,13 +36,13 @@ validateStories:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 getStoriesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.stories_location}
   result: storiesFile
@@ -50,7 +50,7 @@ getStoriesFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${storiesFile.response.body.file}
   result: storiesData
@@ -58,7 +58,7 @@ convertYamlToJson:
 mergeStories:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge
     body:
       array1: ${storiesData.response.body.stories}
       array2: ${[body]}
@@ -68,7 +68,7 @@ mergeStories:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       version: "3.0"
       stories: ${mergedStories.response.body}
@@ -77,7 +77,7 @@ convertJsonToYaml:
 saveStoriesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.stories_location}
       content: ${storiesYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/test-stories.yml
+++ b/DSL/Ruuter.private/POST/rasa/test-stories.yml
@@ -20,7 +20,7 @@ validatePermission:
 getTestStoriesWithName:
   call: http.post
   args:
-    url: http://host.docker.internal:9200/test-stories/_search/template
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/test-stories/_search/template"
     body:
       id: "test-story-with-name"
       params: ${params}
@@ -29,7 +29,7 @@ getTestStoriesWithName:
 mapTestStoriesData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-test-stories
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-test-stories"
     body:
       hits: ${getTestStoriesResult.response.body.hits.hits}
   result: testStoriesData

--- a/DSL/Ruuter.private/POST/rasa/test-stories/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/test-stories/add.yml
@@ -20,7 +20,7 @@ validatePermission:
 getTestStoriesWithName:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/test-stories
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/test-stories"
     headers:
       cookie: ${cookie}
     body:
@@ -36,13 +36,13 @@ validateTestStories:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 getStoriesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.test_stories_location}
   result: testStoriesFile
@@ -50,7 +50,7 @@ getStoriesFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${testStoriesFile.response.body.file}
   result: testStoriesData
@@ -58,7 +58,7 @@ convertYamlToJson:
 mergeStories:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge
     body:
       array1: ${testStoriesData.response.body.stories}
       array2: ${[parameters]}
@@ -68,7 +68,7 @@ mergeStories:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       stories: ${mergedTestStories.response.body}
   result: testStoriesYaml
@@ -76,7 +76,7 @@ convertJsonToYaml:
 saveFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.test_stories_location}
       content: ${testStoriesYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/test-stories/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/test-stories/delete.yml
@@ -20,7 +20,7 @@ validatePermission:
 getTestStoriesWithName:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/test-stories
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/test-stories"
     headers:
       cookie: ${cookie}
     body:
@@ -36,13 +36,13 @@ validateTestStories:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 getStoriesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.test_stories_location}
   result: testStoriesFile
@@ -50,7 +50,7 @@ getStoriesFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${testStoriesFile.response.body.file}
   result: testStoriesData
@@ -58,7 +58,7 @@ convertYamlToJson:
 deleteTestStory:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/delete-story
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/delete-story
     body:
       stories: ${testStoriesData.response.body.stories}
       story_name: ${story}
@@ -67,7 +67,7 @@ deleteTestStory:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       stories: ${deleteTestStoriesData.response.body}
   result: testStoriesYaml
@@ -75,7 +75,7 @@ convertJsonToYaml:
 saveFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.test_stories_location}
       content: ${testStoriesYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/test-stories/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/test-stories/update.yml
@@ -20,7 +20,7 @@ validatePermission:
 getTestStoriesWithName:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/test-stories
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/test-stories"
     headers:
       cookie: ${cookie}
     body:
@@ -36,13 +36,13 @@ validateTestStories:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 getStoriesFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.test_stories_location}
   result: testStoriesFile
@@ -50,7 +50,7 @@ getStoriesFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/yaml-to-json
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/yaml-to-json
     body:
       file: ${testStoriesFile.response.body.file}
   result: testStoriesData
@@ -58,7 +58,7 @@ convertYamlToJson:
 mergeStories:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/merge
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/merge
     body:
       array1: ${testStoriesData.response.body.stories}
       array2: ${[parameters]}
@@ -68,7 +68,7 @@ mergeStories:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/convert/json-to-yaml
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/convert/json-to-yaml
     body:
       stories: ${mergedTestStories.response.body}
   result: testStoriesYaml
@@ -76,7 +76,7 @@ convertJsonToYaml:
 saveFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/write
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/write
     body:
       file_path: ${fileLocations.response.body.response.test_stories_location}
       content: ${testStoriesYaml.response.body.json}

--- a/DSL/Ruuter.private/POST/rasa/training/command.yml
+++ b/DSL/Ruuter.private/POST/rasa/training/command.yml
@@ -21,7 +21,7 @@ runCommand:
   call: http.post
   args:
     #TODO: Implement the command execution logic
-    url: http://host.docker.internal:3000/dmapper/execute-command
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/execute-command
     body:
       command: ${parameters.command}
   result: commandResponse

--- a/DSL/Ruuter.private/POST/rasa/training/results.yml
+++ b/DSL/Ruuter.private/POST/rasa/training/results.yml
@@ -20,13 +20,13 @@ validatePermission:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 checkModelExists:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/check
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/check
     body:
       file_path: ${fileLocations.response.body.response.training_result_location + '/' + parameters.trained_model}
   result: modelExists
@@ -40,7 +40,7 @@ validateModelExists:
 getTrainedModel:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read-directory
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read-directory
     body:
       file_path: ${fileLocations.response.body.response.training_result_location + '/' + parameters.trained_model}
   result: trainingResults

--- a/DSL/Ruuter.private/POST/rasa/training/results/files.yml
+++ b/DSL/Ruuter.private/POST/rasa/training/results/files.yml
@@ -20,13 +20,13 @@ validatePermission:
 getFileLocations:
   call: http.get
   args:
-    url: http://localhost:8080/return-file-locations
+    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
   result: fileLocations
 
 checkModelFileExists:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/check
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/check
     body:
       file_path: ${fileLocations.response.body.response.training_result_location + '/' + parameters.trained_model + '/' + parameters.file_name}
   result: fileExists
@@ -40,7 +40,7 @@ validateFileExists:
 getTrainedModelFile:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/file/read
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/file/read
     body:
       file_path: ${fileLocations.response.body.response.training_result_location + '/' + parameters.trained_model + '/' + parameters.file_name}
   result: modelFile

--- a/DSL/Ruuter.private/POST/rasa/training/validate.yml
+++ b/DSL/Ruuter.private/POST/rasa/training/validate.yml
@@ -21,7 +21,7 @@ runCommand:
   call: http.post
   args:
     #TODO: Implement the command execution logic
-    url: http://host.docker.internal:3000/dmapper/execute-command
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/execute-command
     body:
       command: ${parameters.command}
   result: commandResponse


### PR DESCRIPTION
Changed a total of 74 files in the DSL folder, by adding parameters to the urls.

Made the following changes to the urls:
1) url: http://localhost:8080/... -> url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/..." ;
2) url: http://host.docker.internal:3000/... -> url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/..." ; 
3) url: http://host.docker.internal:9200/... -> url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/..." ; 
4) url: http://localhost:9200/... -> "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/..." (including urls in the curl requests) ; 
5) url: http://data_mapper:3005/... -> 
url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/..." (only 1 mapping in the DSL/Ruuter.private/POST/csv.yml file)