### PR TITLE
#77 - Get a List of Rasa Intents

### DIFF
--- a/DSL/Ruuter.private/GET/rasa/intents.yml
+++ b/DSL/Ruuter.private/GET/rasa/intents.yml
@@ -16,7 +16,3 @@ mapIntentsData:
 returnSuccess:
   return: ${intentsData.response.body}
   next: end
-
-returnUnauthorized:
-  return: "error: unauthorized"
-  next: end

--- a/DSL/Ruuter.private/POST/mock-tim.yml
+++ b/DSL/Ruuter.private/POST/mock-tim.yml
@@ -1,0 +1,20 @@
+mockValue:
+  call: reflect.mock
+  args:
+    response:
+      sub: ""
+      firstName: "MARY ÄNN"
+      idCode: "EE60001019906"
+      displayName: "MARY ÄNN"
+      iss: "test.buerokratt.ee"
+      exp: 1670250948
+      login: "EE60001019906"
+      iat: 1670243748
+      jti: "e14a5084-3b30-4a55-8720-c2ee22f43c2c"
+      authorities: [
+        "ROLE_ADMINISTRATOR"
+      ]
+  result: reflectedRequest
+
+returnMockValue:
+  return: ${reflectedRequest.response.body}

--- a/DSL/Ruuter.private/POST/rasa/.guard
+++ b/DSL/Ruuter.private/POST/rasa/.guard
@@ -1,0 +1,23 @@
+authenticate:
+  template: extract-token
+  requestType: post
+  headers:
+    cookie: ${incoming.headers.testcookie}
+  body:
+    role: "ROLE_ADMINISTRATOR"
+  result: permission
+
+validate_permission:
+  switch:
+    - condition: ${permission}
+      next: guard_success
+  next: guard_fail
+
+guard_success:
+  return: "success"
+  status: 200
+  next: end
+
+guard_fail:
+  return: "unauthorized"
+  status: 403

--- a/DSL/Ruuter.private/POST/rasa/intents.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents.yml
@@ -2,21 +2,6 @@ assign_values:
   assign:
     params: ${incoming.body}
 
-authenticate:
-  template: extract-token
-  requestType: post
-  headers:
-    cookie: ${incoming.headers.cookie}
-  body:
-    role: "ROLE_ADMINISTRATOR"
-  result: permission
-
-validatePermission:
-  switch:
-    - condition: ${permission}
-      next: getIntentsWithName
-  next: returnUnauthorized
-
 getIntentsWithName:
   call: http.post
   args:


### PR DESCRIPTION
This pull request completes the final necessary pieces for the intents script to work, as most of the work had already been done in a previous pull request, #230. Currently, the script to fetch intent titles fetches data from OpenSearch, and OpenSearch fetches it from its own custom mocks in DSL/OpenSearch/mock. 

![Postman_mnJptU8bRo](https://github.com/buerokratt/Training-Module/assets/31955511/0d9a3815-9dc5-48b5-b1f5-d20836cba9fb)
