### PR TITLE
#80 - Count examples in intent

### DIFF
--- a/DSL/Ruuter.private/GET/domain-file.yml
+++ b/DSL/Ruuter.private/GET/domain-file.yml
@@ -23,7 +23,3 @@ convertYamlToJson:
 returnSuccess:
   return: ${domainData.response.body}
   next: end
-
-returnUnauthorized:
-  return: "error: unauthorized"
-  next: end

--- a/DSL/Ruuter.private/GET/rasa/intents/examples/count.yml
+++ b/DSL/Ruuter.private/GET/rasa/intents/examples/count.yml
@@ -1,18 +1,3 @@
-authenticate:
-  template: extract-token
-  requestType: post
-  headers:
-    cookie: ${incoming.headers.cookie}
-  body:
-    role: "ROLE_ADMINISTRATOR"
-  result: permission
-
-validatePermission:
-  switch:
-    - condition: ${permission}
-      next: getIntentsExampleCount
-  next: returnUnauthorized
-
 getIntentsExampleCount:
   call: http.post
   args:
@@ -34,8 +19,4 @@ mapIntentsData:
 
 returnSuccess:
   return: ${intentsData.response.body}
-  next: end
-
-returnUnauthorized:
-  return: "error: unauthorized"
   next: end

--- a/DSL/Ruuter.private/GET/rasa/intents/in-model.yml
+++ b/DSL/Ruuter.private/GET/rasa/intents/in-model.yml
@@ -3,7 +3,7 @@ getDomainFile:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
-      cookie: ${cookie}
+      testcookie: "test"
   result: domainData
 
 returnSuccess:

--- a/DSL/Ruuter.private/POST/rasa/intents/examples.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/examples.yml
@@ -1,6 +1,6 @@
 assign_values:
   assign:
-    params: ${incoming.body}
+    params: ${incoming.params}
 
 getIntentsWithName:
   call: http.post
@@ -8,7 +8,7 @@ getIntentsWithName:
     url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/intents/_search/template"
     body:
       id: "intent-with-name"
-      params: ${incoming.params}
+      params: ${params}
   result: getIntentsResult
   next: mapIntentsData
 

--- a/DSL/Ruuter.private/POST/rasa/intents/examples/count.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/examples/count.yml
@@ -1,21 +1,6 @@
 assign_values:
   assign:
-    params: ${incoming.body}
-
-authenticate:
-  template: extract-token
-  requestType: post
-  headers:
-    cookie: ${incoming.headers.cookie}
-  body:
-    role: "ROLE_ADMINISTRATOR"
-  result: permission
-
-validatePermission:
-  switch:
-    - condition: ${permission}
-      next: getIntentsExampleCount
-  next: returnUnauthorized
+    params: ${incoming.params}
 
 getIntentsExampleCount:
   call: http.post
@@ -37,8 +22,4 @@ mapIntentsData:
 
 returnSuccess:
   return: ${intentsData.response.body}
-  next: end
-
-returnUnauthorized:
-  return: "error: unauthorized"
   next: end


### PR DESCRIPTION
For issue: #80 

This pull request completes the final necessary pieces for querying example counts to work, as most of the work had already been done in a previous pull request, #230 . 

**Currently, the script to fetch example counts in an intent fetches data from OpenSearch, and OpenSearch fetches it from its own custom mocks in DSL/OpenSearch/mock.**

- Edited and cleaned up authentication parts in the YML files.
- Fixed one little issue with the syntax of incoming params.
- Verified that the request works.

GET:

![image](https://github.com/buerokratt/Training-Module/assets/31955511/24eb2c41-c06b-41d8-8ebe-bdce2e2c17a6)


POST:

![image](https://github.com/buerokratt/Training-Module/assets/31955511/d316420a-0950-4685-a297-2415181f0901)
