### PR TITLE
#75 - Get intent in-model status

### DIFF
--- a/DSL/Ruuter.private/GET/domain-file.yml
+++ b/DSL/Ruuter.private/GET/domain-file.yml
@@ -23,7 +23,3 @@ convertYamlToJson:
 returnSuccess:
   return: ${domainData.response.body}
   next: end
-
-returnUnauthorized:
-  return: "error: unauthorized"
-  next: end

--- a/DSL/Ruuter.private/GET/rasa/intents/in-model.yml
+++ b/DSL/Ruuter.private/GET/rasa/intents/in-model.yml
@@ -3,7 +3,7 @@ getDomainFile:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
-      cookie: ${cookie}
+      testcookie: "test"
   result: domainData
 
 returnSuccess:


### PR DESCRIPTION
For issue: #75

This pull request completes the final necessary pieces for querying example counts to work, as most of the work had already been done in a previous pull request, #230 . 

**Currently, the script to fetch a lot of the other data in intents functionality go through OpenSearch, and OpenSearch fetches it from its own custom mocks in DSL/OpenSearch/mock. This script fetches it straight from YML**

- Edited and cleaned up authentication parts in the YML files.
- Fixed one little issue with the syntax of incoming params.
- Verified that the request works.