### PR TITLE
 #122  REST service to update an existing Rasa entity

### DIFF
--- a/DSL/Ruuter.private/POST/rasa/entities/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/entities/update.yml
@@ -2,27 +2,10 @@ assign_values:
   assign:
     parameters: ${incoming.body}
 
-authenticate:
-  template: extract-token
-  requestType: post
-  headers:
-    cookie: ${incoming.headers.cookie}
-  body:
-    role: "ROLE_ADMINISTRATOR"
-  result: permission
-
-validatePermission:
-  switch:
-    - condition: ${permission}
-      next: getDomainFile
-  next: returnUnauthorized
-
 getDomainFile:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
-    headers:
-      cookie: ${cookie}
   result: domainData
 
 validateEntities:

--- a/GUI/src/pages/Training/IntentsFollowupTraining/Entities.tsx
+++ b/GUI/src/pages/Training/IntentsFollowupTraining/Entities.tsx
@@ -14,6 +14,7 @@ import { Link } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 
 const Entities: FC = () => {
+  let newEntityName = '';
   const { t } = useTranslation();
   const toast = useToast();
   const queryClient = useQueryClient();
@@ -56,7 +57,7 @@ const Entities: FC = () => {
   });
 
   const entityEditMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string | number, data: { name: string } }) => editEntity(id, data),
+    mutationFn: ({ data }: { data: { entity_name: string, entity: string, intent: string } }) => editEntity(data),
     onSuccess: async () => {
       await queryClient.invalidateQueries(['entities']);
       toast.open({
@@ -97,6 +98,10 @@ const Entities: FC = () => {
 
   const columnHelper = createColumnHelper<Entity>();
 
+  const updateEntityName = (newName: string) => {
+    newEntityName = newName;
+  }
+
   const entitiesColumns = useMemo(() => [
     columnHelper.accessor('name', {
       header: t('training.intents.entities') || '',
@@ -105,6 +110,7 @@ const Entities: FC = () => {
           name={`entity-${props.row.original.id}`}
           label={t('training.intents.entity')}
           defaultValue={editableRow.name}
+          onChange={(e) => updateEntityName(e.target.value)}
           hideLabel
         />
       ) : props.row.original.relatedIntents ? (
@@ -135,8 +141,11 @@ const Entities: FC = () => {
         <>
           {editableRow && editableRow.id === props.row.original.id ? (
             <Button appearance='text' onClick={() => entityEditMutation.mutate({
-              id: props.row.original.id,
-              data: { name: props.row.original.name },
+              data: {
+                entity_name: props.row.original.name,
+                entity: newEntityName,
+                intent: 'regex'
+              },
             })}>
               <Icon
                 label={t('global.save')}

--- a/GUI/src/services/entities.ts
+++ b/GUI/src/services/entities.ts
@@ -1,4 +1,4 @@
-import api from './api';
+import api from './temp-api';
 import { Entity } from 'types/entity';
 
 export async function addEntity(entityData: { name: string }) {
@@ -6,8 +6,11 @@ export async function addEntity(entityData: { name: string }) {
   return data;
 }
 
-export async function editEntity(id: string | number, entityData: { name: string }) {
-  const { data } = await api.patch<Entity>(`entities/${id}`, entityData);
+export async function editEntity(entityData: { entity_name: string, entity: string, intent: string }) {
+  if(entityData.entity.trim().length === 0) {
+    entityData.entity = entityData.entity_name;
+  }
+  const { data } = await api.post<Entity>(`entities/update`, entityData);
   return data;
 }
 


### PR DESCRIPTION
- Entities service now using temp-api file to make requests to ruuter
- Removed old authorization for update dsl
- Updated update method in entities service
- Added check if value is not present to use current entity name as new value