### PR TITLE
Display Last Changed Date from Database on Intent Selection

### DIFF
--- a/DSL/DataMapper/Dockerfile
+++ b/DSL/DataMapper/Dockerfile
@@ -10,6 +10,6 @@ COPY views views
 COPY package.json .
 COPY server.js .
 
-RUN npm i -g npm@latest
+RUN npm i -g npm@9.5.0
 RUN npm install
 ENTRYPOINT ["npm","start"]

--- a/DSL/Pipelines/Dockerfile
+++ b/DSL/Pipelines/Dockerfile
@@ -5,4 +5,5 @@ WORKDIR /usr/src/app
 
 COPY . .
 
+RUN npm install
 ENTRYPOINT ["npm","start"]

--- a/DSL/Resql/get-intent-last-changed.sql
+++ b/DSL/Resql/get-intent-last-changed.sql
@@ -1,1 +1,1 @@
-SELECT * FROM intent WHERE intent = :intent AND status = 'ACTIVE' ORDER BY start_date DESC LIMIT 1;
+SELECT * FROM intent WHERE intent = :intent AND status = 'ACTIVE' ORDER BY created DESC LIMIT 1;

--- a/DSL/Ruuter.private/GET/domain-file.yml
+++ b/DSL/Ruuter.private/GET/domain-file.yml
@@ -2,6 +2,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: {incoming.headers.cookie}
   result: fileLocations
 
 getDomainFile:

--- a/DSL/Ruuter.private/GET/rasa/config.yml
+++ b/DSL/Ruuter.private/GET/rasa/config.yml
@@ -2,6 +2,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: {incoming.headers.cookie}
   result: fileLocations
 
 getConfigFile:

--- a/DSL/Ruuter.private/GET/rasa/intents/in-model.yml
+++ b/DSL/Ruuter.private/GET/rasa/intents/in-model.yml
@@ -3,7 +3,7 @@ getDomainFile:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
-      testcookie: "test"
+      cookie: ${incoming.headers.cookie}
   result: domainData
 
 returnSuccess:

--- a/DSL/Ruuter.private/GET/rasa/intents/intents-full.yml
+++ b/DSL/Ruuter.private/GET/rasa/intents/intents-full.yml
@@ -17,7 +17,7 @@ getDomainFile:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
-      testcookie: "test"
+      cookie: ${incoming.headers.cookie}
   result: getDomainDataResult
 
 getIntentsExampleCount:
@@ -27,6 +27,12 @@ getIntentsExampleCount:
     body:
       id: "intents-with-examples-count"
   result: getIntentCountResult
+
+checkIfIntentsExists:
+  switch:
+    - condition: ${getIntentDataResult.response.body.data.intents != null}
+      next: assignResults
+  next: returnNoIntentsFound
 
 assignResults:
   assign:
@@ -46,4 +52,8 @@ mapIntentsData:
 
 returnSuccess:
   return: ${getIntentDataResult.response.body}
+  next: end
+
+returnNoIntentsFound:
+  return: "Error: no intents found"
   next: end

--- a/DSL/Ruuter.private/GET/rasa/training/results.yml
+++ b/DSL/Ruuter.private/GET/rasa/training/results.yml
@@ -2,6 +2,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 getTrainingResultsDirectory:

--- a/DSL/Ruuter.private/GET/rules-file.yml
+++ b/DSL/Ruuter.private/GET/rules-file.yml
@@ -2,6 +2,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 getRulesFile:

--- a/DSL/Ruuter.private/GET/stories-file.yml
+++ b/DSL/Ruuter.private/GET/stories-file.yml
@@ -2,6 +2,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 getStoriesFile:

--- a/DSL/Ruuter.private/POST/rasa/config/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/config/update.yml
@@ -7,6 +7,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 convertJsonToYaml:

--- a/DSL/Ruuter.private/POST/rasa/entities/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/entities/add.yml
@@ -6,6 +6,8 @@ getDomainFile:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: domainData
 
 validateEntities:
@@ -42,6 +44,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 saveDomainFile:

--- a/DSL/Ruuter.private/POST/rasa/entities/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/entities/delete.yml
@@ -6,6 +6,8 @@ getDomainFile:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: domainData
 
 validateEntities:
@@ -18,6 +20,8 @@ domainEntities:
   call: http.post
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/entities"
+    headers:
+      cookie: ${incoming.headers.cookie}
     body:
       entity: ${parameters.entity_name}
   result: domainEntities
@@ -32,6 +36,8 @@ regexEntities:
   call: http.post
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/regex"
+    headers:
+      cookie: ${incoming.headers.cookie}
     body:
       regex: ${parameters.entity_name}
       examples: false
@@ -47,6 +53,8 @@ intentEntities:
   call: http.post
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/examples/entities"
+    headers:
+      cookie: ${incoming.headers.cookie}
     body:
       entity: ${parameters.entity_name}
       examples: false
@@ -86,6 +94,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 saveDomainFile:

--- a/DSL/Ruuter.private/POST/rasa/entities/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/entities/update.yml
@@ -6,6 +6,8 @@ getDomainFile:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: domainData
 
 validateEntities:
@@ -43,6 +45,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 saveDomainFile:

--- a/DSL/Ruuter.private/POST/rasa/forms/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/forms/add.yml
@@ -8,7 +8,7 @@ getDomainFile:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
   result: domainData
 
 validateForms:
@@ -45,6 +45,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 saveDomainFile:

--- a/DSL/Ruuter.private/POST/rasa/forms/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/forms/delete.yml
@@ -8,7 +8,7 @@ getDomainFile:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
   result: domainData
 
 validateForms:
@@ -22,7 +22,7 @@ ruleForms:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules/search"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
     body:
       form: ${parameters.form_name}
       type: "forms"
@@ -39,7 +39,7 @@ storiesForms:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories/search"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
     body:
       form: ${parameters.form_name}
       type: "forms"
@@ -79,6 +79,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 saveDomainFile:

--- a/DSL/Ruuter.private/POST/rasa/forms/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/forms/update.yml
@@ -8,7 +8,7 @@ getDomainFile:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
   result: domainData
 
 validateForms:
@@ -45,6 +45,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 saveDomainFile:

--- a/DSL/Ruuter.private/POST/rasa/intents/add-remove-from-model.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/add-remove-from-model.yml
@@ -8,7 +8,7 @@ getDomainFile:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
-      testcookie: "test"
+      cookie: ${incoming.headers.cookie}
   result: domainData
 
 isInModel:
@@ -63,6 +63,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 saveDomainFile:

--- a/DSL/Ruuter.private/POST/rasa/intents/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/add.yml
@@ -12,6 +12,8 @@ getIntentList:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/intents"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: intentList
 
 validateIntentExists:
@@ -26,6 +28,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 mapIntentsData:

--- a/DSL/Ruuter.private/POST/rasa/intents/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/delete.yml
@@ -7,6 +7,8 @@ getIntentList:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/intents"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: intentList
 
 validateIntentExists:
@@ -21,6 +23,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 assignFilePath:
@@ -201,6 +205,8 @@ getDomainFile:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: domainData
 
 validateExistsInDomain:

--- a/DSL/Ruuter.private/POST/rasa/intents/download.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/download.yml
@@ -6,12 +6,16 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 getIntentFile:
   call: http.post
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/intents/get-intent-file"
+    headers:
+      cookie: ${incoming.headers.cookie}
     body:
       intentName: ${incoming.body.intentName}
       returnType: "json"

--- a/DSL/Ruuter.private/POST/rasa/intents/examples/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/examples/add.yml
@@ -23,6 +23,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 assignFilePath:

--- a/DSL/Ruuter.private/POST/rasa/intents/examples/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/examples/delete.yml
@@ -7,6 +7,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 assignFilePath:

--- a/DSL/Ruuter.private/POST/rasa/intents/examples/list.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/examples/list.yml
@@ -6,6 +6,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 assignFilePath:

--- a/DSL/Ruuter.private/POST/rasa/intents/examples/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/examples/update.yml
@@ -8,6 +8,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 assignFilePath:

--- a/DSL/Ruuter.private/POST/rasa/intents/get-intent-file.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/get-intent-file.yml
@@ -7,6 +7,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 assignFilePath:

--- a/DSL/Ruuter.private/POST/rasa/intents/last-modified.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/last-modified.yml
@@ -1,0 +1,15 @@
+assignParameters:
+  assign:
+    intent: ${incoming.body.intentName}
+
+getLastChanged:
+  call: http.post
+  args:
+    url: "[#TRAINING_RESQL]:[#TRAINING_RESQL_PORT]/get-intent-last-changed"
+    body:
+        intent: ${intent}
+  result: lastChangedResult
+
+returnStep:
+  return: ${lastChangedResult.response.body[0].created}
+  next: end

--- a/DSL/Ruuter.private/POST/rasa/intents/turn-into-service.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/turn-into-service.yml
@@ -1,16 +1,13 @@
 assign_values:
   assign:
     intentName: ${incoming.body.intentName.replaceAll(/\s+/g, "_")}
-    # TODO: Revert back
-    # cookie: ${incoming.headers.cookie}
-    cookie: "Cookie"
 
 extract_token_data:
   call: http.post
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/mock-tim-custom-jwt-userinfo"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
     body:
       cookieName: "customJwtCookie"
   result: jwtResult
@@ -26,7 +23,7 @@ get_domain_file:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
   result: domainData
 
 validate_intent_exists:
@@ -39,6 +36,8 @@ get_file_locations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 get_existing_intent_file:

--- a/DSL/Ruuter.private/POST/rasa/intents/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/update.yml
@@ -13,6 +13,8 @@ getIntentList:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/intents"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: intentList
 
 validateIntentExists:
@@ -27,6 +29,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 assignFilePath:
@@ -278,6 +282,8 @@ getDomainFile:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: domainData
 
 validateExistsInDomain:

--- a/DSL/Ruuter.private/POST/rasa/intents/upload.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/upload.yml
@@ -22,6 +22,8 @@ addExamples:
   call: http.post
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/intents/examples/add"
+    headers:
+      cookie: ${incoming.headers.cookie}
     body:
       intentName: ${intentName}
       intentExamples: []

--- a/DSL/Ruuter.private/POST/rasa/regex/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/regex/delete.yml
@@ -6,6 +6,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 getRegexFile:

--- a/DSL/Ruuter.private/POST/rasa/regex/example.yml
+++ b/DSL/Ruuter.private/POST/rasa/regex/example.yml
@@ -6,6 +6,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 getRegexFile:

--- a/DSL/Ruuter.private/POST/rasa/regex/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/regex/update.yml
@@ -6,6 +6,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 getRegexFile:

--- a/DSL/Ruuter.private/POST/rasa/responses/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/responses/add.yml
@@ -6,6 +6,8 @@ getDomainFile:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: domainData
 
 validateResponse:
@@ -44,6 +46,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 saveDomainFile:

--- a/DSL/Ruuter.private/POST/rasa/responses/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/responses/delete.yml
@@ -6,6 +6,8 @@ getDomainFile:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: domainData
 
 validateResponse:
@@ -18,6 +20,8 @@ ruleResponses:
   call: http.post
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules/search"
+    headers:
+      cookie: ${incoming.headers.cookie}
     body:
       response: ${parameters.response_name}
       type: "responses"
@@ -33,6 +37,8 @@ storiesResponses:
   call: http.post
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories/search"
+    headers:
+      cookie: ${incoming.headers.cookie}
     body:
       response: ${parameters.response_name}
       type: "responses"
@@ -72,6 +78,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 saveDomainFile:

--- a/DSL/Ruuter.private/POST/rasa/responses/dependencies.yml
+++ b/DSL/Ruuter.private/POST/rasa/responses/dependencies.yml
@@ -23,7 +23,7 @@ ruleResponses:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules/search"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
     body:
       response: ${params.response_name}
       type: "responses"
@@ -34,7 +34,7 @@ storiesResponses:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories/search"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
     body:
       response: ${params.response_name}
       type: "responses"

--- a/DSL/Ruuter.private/POST/rasa/responses/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/responses/update.yml
@@ -6,8 +6,8 @@ getDomainFile:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
-#    headers:
-#      cookie: ${cookie}
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: domainData
 
 validateResponse:
@@ -46,6 +46,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 saveDomainFile:

--- a/DSL/Ruuter.private/POST/rasa/rules/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/rules/add.yml
@@ -6,6 +6,8 @@ getRuleWithName:
   call: http.post
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules"
+    headers:
+      cookie: ${incoming.headers.cookie}
     body:
       rule: ${body.rule}
   result: ruleResult
@@ -20,6 +22,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 getRulesFile:

--- a/DSL/Ruuter.private/POST/rasa/rules/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/rules/delete.yml
@@ -6,6 +6,8 @@ getRuleWithName:
   call: http.post
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules"
+    headers:
+      cookie: ${incoming.headers.cookie}
     body:
       rule: ${rule}
   result: ruleResult
@@ -20,6 +22,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 getRulesFile:

--- a/DSL/Ruuter.private/POST/rasa/rules/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/rules/update.yml
@@ -6,6 +6,8 @@ getRuleWithName:
   call: http.post
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules"
+    headers:
+      cookie: ${incoming.headers.cookie}
     body:
       rule: ${body.rule}
   result: ruleResult
@@ -20,6 +22,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 getRulesFile:

--- a/DSL/Ruuter.private/POST/rasa/slots/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/slots/add.yml
@@ -8,7 +8,7 @@ getDomainFile:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
   result: domainData
 
 validateSlots:
@@ -45,6 +45,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 saveDomainFile:

--- a/DSL/Ruuter.private/POST/rasa/slots/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/slots/delete.yml
@@ -8,7 +8,7 @@ getDomainFile:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
   result: domainData
 
 validateSlots:
@@ -22,7 +22,7 @@ formSlots:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/forms/search"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
     body:
       slot: ${parameters.slot_name}
   result: formSlots
@@ -38,7 +38,7 @@ ruleSlots:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules/search"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
     body:
       slot: ${parameters.slot_name}
       type: "slots"
@@ -55,7 +55,7 @@ storiesSlots:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories/search"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
     body:
       slot: ${parameters.slot_name}
       type: "slots"
@@ -95,6 +95,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 saveDomainFile:

--- a/DSL/Ruuter.private/POST/rasa/slots/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/slots/update.yml
@@ -8,7 +8,7 @@ getDomainFile:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
   result: domainData
 
 validateSlots:
@@ -45,6 +45,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 saveDomainFile:

--- a/DSL/Ruuter.private/POST/rasa/stories/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/add.yml
@@ -6,6 +6,8 @@ getStoriesWithName:
   call: http.post
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories"
+    headers:
+      cookie: ${incoming.headers.cookie}
     body:
       story: ${body.story}
   result: storiesResult
@@ -20,6 +22,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 getStoriesFile:

--- a/DSL/Ruuter.private/POST/rasa/stories/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/delete.yml
@@ -6,6 +6,8 @@ getStoriesWithName:
   call: http.post
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories"
+    headers:
+      cookie: ${incoming.headers.cookie}
     body:
       story: ${story}
   result: storiesResult
@@ -20,6 +22,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 getStoriesFile:

--- a/DSL/Ruuter.private/POST/rasa/stories/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/update.yml
@@ -6,6 +6,8 @@ getStoriesWithName:
   call: http.post
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories"
+    headers:
+      cookie: ${incoming.headers.cookie}
     body:
       story: ${body.story}
   result: storiesResult
@@ -20,6 +22,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 getStoriesFile:

--- a/DSL/Ruuter.private/POST/rasa/test-stories/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/test-stories/add.yml
@@ -8,7 +8,7 @@ getTestStoriesWithName:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/test-stories"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
     body:
       story: ${parameters.story}
   result: testStoriesResult
@@ -23,6 +23,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 getStoriesFile:

--- a/DSL/Ruuter.private/POST/rasa/test-stories/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/test-stories/delete.yml
@@ -8,7 +8,7 @@ getTestStoriesWithName:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/test-stories"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
     body:
       story: ${story}
   result: testStoriesResult
@@ -23,6 +23,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 getStoriesFile:

--- a/DSL/Ruuter.private/POST/rasa/test-stories/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/test-stories/update.yml
@@ -8,7 +8,7 @@ getTestStoriesWithName:
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/test-stories"
     headers:
-      cookie: ${cookie}
+      cookie: ${incoming.headers.cookie}
     body:
       story: ${parameters.story}
   result: testStoriesResult
@@ -23,6 +23,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 getStoriesFile:

--- a/DSL/Ruuter.private/POST/rasa/training/results.yml
+++ b/DSL/Ruuter.private/POST/rasa/training/results.yml
@@ -7,6 +7,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 checkModelExists:

--- a/DSL/Ruuter.private/POST/rasa/training/results/files.yml
+++ b/DSL/Ruuter.private/POST/rasa/training/results/files.yml
@@ -7,6 +7,8 @@ getFileLocations:
   call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    headers:
+      cookie: ${incoming.headers.cookie}
   result: fileLocations
 
 checkModelFileExists:

--- a/GUI/src/pages/Training/Intents/index.tsx
+++ b/GUI/src/pages/Training/Intents/index.tsx
@@ -159,6 +159,17 @@ const Intents: FC = () => {
     }
   });
 
+  const intentModifiedMutation = useMutation({
+    mutationFn: (data: { intentName: string }) => getLastModified(data),
+    onError: (error: AxiosError) => {
+      toast.open({
+        type: 'error',
+        title: t('global.notificationError'),
+        message: error.message,
+      });
+    },
+  });
+
   const turnIntentIntoServiceMutation = useMutation({
     mutationFn: ({ intent }: { intent: Intent }) => turnIntentIntoService(intent),
     onSuccess: async (_, { intent }) => {
@@ -187,18 +198,27 @@ const Intents: FC = () => {
   }, [intents, filter]);
 
   const handleTabsValueChange = useCallback(
-    (value: string) => {
-      setEditingIntentTitle(null);
-      if (!intents) return;
-      const selectedIntent = intents.find((intent) => intent.intent === value);
-      if (selectedIntent) {
-        selectedIntent.modifiedAt = lastModifiedMutation.mutate(selectedIntent.intent);
-        setSelectedIntent(selectedIntent);
-        setSelectedTab(selectedIntent.intent);
-      }
-    },
-    [intents]
+      (value: string) => {
+        setEditingIntentTitle(null);
+        setSelectedIntent(null);
+        if (!intents) return;
+        const selectedIntent = intents.find((intent) => intent.intent === value);
+        if (selectedIntent) {
+          intentModifiedMutation.mutate(
+              { intentName: selectedIntent.intent },
+              {
+                onSuccess: (data) => {
+                  selectedIntent.modifiedAt = data.response;
+                  setSelectedIntent(selectedIntent);
+                  setSelectedTab(selectedIntent.intent);
+                },
+              }
+          );
+        }
+      },
+      [intentModifiedMutation, intents]
   );
+
 
   const newIntentMutation = useMutation({
     mutationFn: (data: { name: string }) => addIntent(data),
@@ -340,22 +360,7 @@ const Intents: FC = () => {
     });
   };
 
-  // const lastModifiedMutation = useMutation({
-  //   mutationFn: (intentModifiedData: { intentName: string }) => {
-  //       selectedIntent?.modifiedAt = getLastModified(intentModifiedData);
-  //   },
-  //   onSuccess: () => {
-  //   },
-  //   onError: (error: AxiosError) => {
-  //     toast.open({
-  //       type: 'error',
-  //       title: t('global.notificationError'),
-  //       message: error.message,
-  //     });
-  //   },
-  // });
-
-  const handleIntentExamplesUpload = (intentId: string | number) => {
+  const handleIntentExamplesUpload = () => {
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = '.csv';
@@ -505,16 +510,15 @@ const Intents: FC = () => {
                         </Button>
                       )}
                     </Track>
-                    <p style={{ color: '#4D4F5D' }}>{t('global.modifiedAt')}:
+                    <p style={{ color: '#4D4F5D' }}>
+                      {t('global.modifiedAt')}:
                       {isValidDate(selectedIntent.modifiedAt) ? (
-                          ` ${format(
-                              new Date(selectedIntent.modifiedAt),
-                              'dd.MM.yyyy'
-                          )}`
+                          ` ${format(new Date(selectedIntent.modifiedAt), 'dd.MM.yyyy')}`
                       ) : (
                           ` ${t('global.missing')}`
                       )}
                     </p>
+
 
                   </Track>
                   <Track justify="end" gap={8} isMultiline={true}>
@@ -529,7 +533,7 @@ const Intents: FC = () => {
                     <Button
                       appearance="secondary"
                       onClick={() =>
-                        handleIntentExamplesUpload(selectedIntent.id)
+                        handleIntentExamplesUpload()
                       }
                     >
                       {t('training.intents.upload')}

--- a/GUI/src/pages/Training/Intents/index.tsx
+++ b/GUI/src/pages/Training/Intents/index.tsx
@@ -20,7 +20,7 @@ import {
   addExample,
   addIntent, addRemoveIntentModel,
   deleteIntent, downloadExamples,
-  editIntent,
+  editIntent, getLastModified,
   turnIntentIntoService, uploadExamples,
 } from 'services/intents';
 import IntentExamplesTable from './IntentExamplesTable';
@@ -192,6 +192,7 @@ const Intents: FC = () => {
       if (!intents) return;
       const selectedIntent = intents.find((intent) => intent.intent === value);
       if (selectedIntent) {
+        selectedIntent.modifiedAt = lastModifiedMutation.mutate(selectedIntent.intent);
         setSelectedIntent(selectedIntent);
         setSelectedTab(selectedIntent.intent);
       }
@@ -338,6 +339,21 @@ const Intents: FC = () => {
         newExamples: example
     });
   };
+
+  // const lastModifiedMutation = useMutation({
+  //   mutationFn: (intentModifiedData: { intentName: string }) => {
+  //       selectedIntent?.modifiedAt = getLastModified(intentModifiedData);
+  //   },
+  //   onSuccess: () => {
+  //   },
+  //   onError: (error: AxiosError) => {
+  //     toast.open({
+  //       type: 'error',
+  //       title: t('global.notificationError'),
+  //       message: error.message,
+  //     });
+  //   },
+  // });
 
   const handleIntentExamplesUpload = (intentId: string | number) => {
     const input = document.createElement('input');

--- a/GUI/src/services/intents.ts
+++ b/GUI/src/services/intents.ts
@@ -23,6 +23,11 @@ export async function addRemoveIntentModel(intentModelData: {name: string, inMod
   return data;
 }
 
+export async function getLastModified(intentModifiedData: {intentName: string}) {
+  const { data } = await api.post(`intents/modified`, intentModifiedData);
+  return data;
+}
+
 export async function addExample(addExampleData: { intentName: string, intentExamples: string[], newExamples: string }) {
   const { data } = await api.post<{ intentName: string; example: string; }>(`intents/examples/add`, addExampleData);
   return data;

--- a/GUI/src/services/intents.ts
+++ b/GUI/src/services/intents.ts
@@ -24,7 +24,7 @@ export async function addRemoveIntentModel(intentModelData: {name: string, inMod
 }
 
 export async function getLastModified(intentModifiedData: {intentName: string}) {
-  const { data } = await api.post(`intents/modified`, intentModifiedData);
+  const { data } = await api.post(`intents/last-modified`, intentModifiedData);
   return data;
 }
 


### PR DESCRIPTION
This pull request finalizes and fixes any changes needed to properly parse and display the 'last changed' date of any selected intent in the GUI. This data is rather minute, a response with a single field. It gets automatically queried whenever a new tab is selected. If the value can be properly parsed into a date and becomes 'truthy', it is shown. If for some reason the date is unavailable, the GUI will keep working and display 'unknown'.

In addition to that, the pull request contains the necessary addition a cookie into all requests in which Ruuter queries itself across all of the DSLs in use throughout the Training Module. This ensures that the cookie is not lost and gets properly carried between cycles of requests, all of which trigger the .guard files that require it.

- Added and cleaned up the SQL and front-end query for last modified intent data.
- Added request headers to all instances in which Ruuter queries itself to keep carrying the cookie.