### PR TITLE
Ruuter Address Constants (Fix)

### DIFF
--- a/DSL/Ruuter.private/GET/domain-file.yml
+++ b/DSL/Ruuter.private/GET/domain-file.yml
@@ -1,7 +1,7 @@
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: {incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/GET/rasa/config.yml
+++ b/DSL/Ruuter.private/GET/rasa/config.yml
@@ -1,7 +1,7 @@
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: {incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/GET/rasa/intents/in-model.yml
+++ b/DSL/Ruuter.private/GET/rasa/intents/in-model.yml
@@ -1,7 +1,7 @@
 getDomainFile:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData

--- a/DSL/Ruuter.private/GET/rasa/intents/intents-full.yml
+++ b/DSL/Ruuter.private/GET/rasa/intents/intents-full.yml
@@ -15,7 +15,7 @@ getIntentsData:
 getDomainFile:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: getDomainDataResult

--- a/DSL/Ruuter.private/GET/rasa/training/results.yml
+++ b/DSL/Ruuter.private/GET/rasa/training/results.yml
@@ -1,7 +1,7 @@
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/GET/rules-file.yml
+++ b/DSL/Ruuter.private/GET/rules-file.yml
@@ -1,7 +1,7 @@
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/GET/stories-file.yml
+++ b/DSL/Ruuter.private/GET/stories-file.yml
@@ -1,7 +1,7 @@
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/extract-token.yml
+++ b/DSL/Ruuter.private/POST/extract-token.yml
@@ -1,7 +1,7 @@
 extractTokenData:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/mock-tim-custom-jwt-userinfo"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${incoming.headers.cookie}
     body:

--- a/DSL/Ruuter.private/POST/rasa/config/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/config/update.yml
@@ -6,7 +6,7 @@ assign_values:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/entities/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/entities/add.yml
@@ -5,7 +5,7 @@ assign_values:
 getDomainFile:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -43,7 +43,7 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/entities/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/entities/delete.yml
@@ -5,7 +5,7 @@ assign_values:
 getDomainFile:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -19,7 +19,7 @@ validateEntities:
 domainEntities:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/entities"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/entities"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -35,7 +35,7 @@ validateDomainEntities:
 regexEntities:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/regex"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/regex"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -52,7 +52,7 @@ validateRegexEntities:
 intentEntities:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/examples/entities"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/examples/entities"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -93,7 +93,7 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/entities/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/entities/update.yml
@@ -5,7 +5,7 @@ assign_values:
 getDomainFile:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -44,7 +44,7 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/forms/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/forms/add.yml
@@ -6,7 +6,7 @@ assign_values:
 getDomainFile:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -44,7 +44,7 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/forms/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/forms/delete.yml
@@ -6,7 +6,7 @@ assign_values:
 getDomainFile:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -20,7 +20,7 @@ validateForms:
 ruleForms:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules/search"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules/search"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -37,7 +37,7 @@ validateRuleForms:
 storiesForms:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories/search"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories/search"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -78,7 +78,7 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/forms/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/forms/update.yml
@@ -6,7 +6,7 @@ assign_values:
 getDomainFile:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -44,7 +44,7 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/intents/add-remove-from-model.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/add-remove-from-model.yml
@@ -6,7 +6,7 @@ assign_values:
 getDomainFile:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -62,7 +62,7 @@ updateDomainOpenSearch:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/intents/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/add.yml
@@ -11,7 +11,7 @@ assign_values:
 getIntentList:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/intents"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/intents"
     headers:
       cookie: ${incoming.headers.cookie}
   result: intentList
@@ -27,7 +27,7 @@ validateIntentExists:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/intents/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/delete.yml
@@ -6,7 +6,7 @@ assign_values:
 getIntentList:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/intents"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/intents"
     headers:
       cookie: ${incoming.headers.cookie}
   result: intentList
@@ -22,7 +22,7 @@ validateIntentExists:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations
@@ -204,7 +204,7 @@ saveIntentFile:
 getDomainFile:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData

--- a/DSL/Ruuter.private/POST/rasa/intents/download.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/download.yml
@@ -5,7 +5,7 @@ assign_values:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations
@@ -13,7 +13,7 @@ getFileLocations:
 getIntentFile:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/intents/get-intent-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/intents/get-intent-file"
     headers:
       cookie: ${incoming.headers.cookie}
     body:

--- a/DSL/Ruuter.private/POST/rasa/intents/examples/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/examples/add.yml
@@ -22,7 +22,7 @@ validateLength:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/intents/examples/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/examples/delete.yml
@@ -6,7 +6,7 @@ assign_values:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/intents/examples/list.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/examples/list.yml
@@ -5,7 +5,7 @@ assign_values:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/intents/examples/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/examples/update.yml
@@ -7,7 +7,7 @@ assign_values:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/intents/get-intent-file.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/get-intent-file.yml
@@ -6,7 +6,7 @@ assignParameters:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/intents/turn-into-service.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/turn-into-service.yml
@@ -5,7 +5,7 @@ assign_values:
 extract_token_data:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/mock-tim-custom-jwt-userinfo"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/mock-tim-custom-jwt-userinfo"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -21,7 +21,7 @@ validate_administrator:
 get_domain_file:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -35,7 +35,7 @@ validate_intent_exists:
 get_file_locations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/intents/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/update.yml
@@ -12,7 +12,7 @@ validateInputLength:
 getIntentList:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/intents"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/intents"
     headers:
       cookie: ${incoming.headers.cookie}
   result: intentList
@@ -28,7 +28,7 @@ validateIntentExists:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations
@@ -281,7 +281,7 @@ deleteOldIntentFile:
 getDomainFile:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData

--- a/DSL/Ruuter.private/POST/rasa/intents/upload.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/upload.yml
@@ -21,7 +21,7 @@ mapCsvToArray:
 addExamples:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/intents/examples/add"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/intents/examples/add"
     headers:
       cookie: ${incoming.headers.cookie}
     body:

--- a/DSL/Ruuter.private/POST/rasa/regex/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/regex/delete.yml
@@ -5,7 +5,7 @@ assign_values:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/regex/example.yml
+++ b/DSL/Ruuter.private/POST/rasa/regex/example.yml
@@ -5,7 +5,7 @@ assign_values:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/regex/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/regex/update.yml
@@ -5,7 +5,7 @@ assign_values:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/responses/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/responses/add.yml
@@ -5,7 +5,7 @@ assign_values:
 getDomainFile:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -45,7 +45,7 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/responses/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/responses/delete.yml
@@ -5,7 +5,7 @@ assign_values:
 getDomainFile:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -19,7 +19,7 @@ validateResponse:
 ruleResponses:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules/search"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules/search"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -36,7 +36,7 @@ validateRuleResponses:
 storiesResponses:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories/search"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories/search"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -77,7 +77,7 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/responses/dependencies.yml
+++ b/DSL/Ruuter.private/POST/rasa/responses/dependencies.yml
@@ -21,7 +21,7 @@ validateResponse:
 ruleResponses:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules/search"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules/search"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -32,7 +32,7 @@ ruleResponses:
 storiesResponses:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories/search"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories/search"
     headers:
       cookie: ${incoming.headers.cookie}
     body:

--- a/DSL/Ruuter.private/POST/rasa/responses/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/responses/update.yml
@@ -5,7 +5,7 @@ assign_values:
 getDomainFile:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -45,7 +45,7 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/rules/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/rules/add.yml
@@ -5,7 +5,7 @@ assign_values:
 getRuleWithName:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -21,7 +21,7 @@ validateRules:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/rules/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/rules/delete.yml
@@ -5,7 +5,7 @@ assign_values:
 getRuleWithName:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -21,7 +21,7 @@ validateRules:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/rules/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/rules/update.yml
@@ -5,7 +5,7 @@ assign_values:
 getRuleWithName:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -21,7 +21,7 @@ validateRules:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/slots/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/slots/add.yml
@@ -6,7 +6,7 @@ assign_values:
 getDomainFile:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -44,7 +44,7 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/slots/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/slots/delete.yml
@@ -6,7 +6,7 @@ assign_values:
 getDomainFile:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -20,7 +20,7 @@ validateSlots:
 formSlots:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/forms/search"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/forms/search"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -36,7 +36,7 @@ validateFormSlots:
 ruleSlots:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules/search"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/rules/search"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -53,7 +53,7 @@ validateRuleSlots:
 storiesSlots:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories/search"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/stories/search"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -94,7 +94,7 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/slots/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/slots/update.yml
@@ -6,7 +6,7 @@ assign_values:
 getDomainFile:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/domain-file"
     headers:
       cookie: ${incoming.headers.cookie}
   result: domainData
@@ -44,7 +44,7 @@ convertJsonToYaml:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/stories/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/add.yml
@@ -5,7 +5,7 @@ assign_values:
 getStoriesWithName:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/story-by-name"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/story-by-name"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -21,7 +21,7 @@ validateStories:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/stories/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/delete.yml
@@ -5,7 +5,7 @@ assign_values:
 getStoriesWithName:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/story-by-name"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/story-by-name"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -21,7 +21,7 @@ validateStories:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/stories/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/update.yml
@@ -6,7 +6,7 @@ assign_values:
 getStoriesWithName:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/story-by-name"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/story-by-name"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -24,7 +24,7 @@ validateStories:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/test-stories/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/test-stories/add.yml
@@ -6,7 +6,7 @@ assign_values:
 getTestStoriesWithName:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/test-stories"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/test-stories"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -22,7 +22,7 @@ validateTestStories:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/test-stories/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/test-stories/delete.yml
@@ -6,7 +6,7 @@ assign_values:
 getTestStoriesWithName:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/test-stories"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/test-stories"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -22,7 +22,7 @@ validateTestStories:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/test-stories/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/test-stories/update.yml
@@ -6,7 +6,7 @@ assign_values:
 getTestStoriesWithName:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/rasa/test-stories"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/rasa/test-stories"
     headers:
       cookie: ${incoming.headers.cookie}
     body:
@@ -22,7 +22,7 @@ validateTestStories:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/training/results.yml
+++ b/DSL/Ruuter.private/POST/rasa/training/results.yml
@@ -6,7 +6,7 @@ extractRequestData:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/DSL/Ruuter.private/POST/rasa/training/results/files.yml
+++ b/DSL/Ruuter.private/POST/rasa/training/results/files.yml
@@ -6,7 +6,7 @@ extractRequestData:
 getFileLocations:
   call: http.get
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]:[#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
+    url: "[#TRAINING_PUBLIC_RUUTER][#TRAINING_PUBLIC_RUUTER_PORT]/return-file-locations"
     headers:
       cookie: ${incoming.headers.cookie}
   result: fileLocations

--- a/GUI/.env
+++ b/GUI/.env
@@ -7,10 +7,6 @@ REACT_APP_SERVICE_MODULE_GUI_BASE_URL=http://localhost:3006
 111REACT_APP_API_BASEURL=http://proto.we.ee/
 111REACT_APP_BASE_URL=http://proto.we.ee/burokratt/
 
-# development-mock
-# development-api
-REACT_APP_MODE=development-mock
-
 111REACT_APP_MOCK_ENABLED=true
 REACT_APP_NODE_ENV=development
 


### PR DESCRIPTION
The purpose of this pull request is to fix how all Ruuter DSLs across Training Module make a call into Ruuter itself. 

We found out through debugging and log-reading that the address Ruuter uses to make requests into itself is faulty with an unnecessary colon, which caused many hard-to-diagnose problems throughout various DSLs used across the entire module. This happened due to it being the case that on the DEV environment (but **not** locally) Ruuter's address in the Ruuter project's own "constants.ini" file is a full one and without a port.

This may be a somewhat temporary solution and it is possible that a larger refactoring is needed for consistency in how constants are referred to in URL field in DSLs, but erasing the colons in all cases where Ruuter calls itself fixes many things in the dev environment and is necessary. 

Because of this change, all developers working with the Ruuter in Training Module locally **must add the colon in their own constants.ini**, for example:

`TRAINING_PUBLIC_RUUTER_PORT=:8080`
(this refers to constants.ini in Ruuter resources)