### PR TITLE
 Fetch a list of all Rasa slots #82 

### DIFF
--- a/DSL/DataMapper/lib/helpers.js
+++ b/DSL/DataMapper/lib/helpers.js
@@ -8,6 +8,22 @@ Handlebars.registerHelper('eq', function(a, b) {
     return a == b;
 });
 
+
+Handlebars.registerHelper('extractSlotKeys', function(obj) {
+    const keys = [];
+    console.log(obj)
+
+    function iterate(obj) {
+        for (const key in obj) {
+            keys.push(key)
+        }
+    }
+
+    iterate(obj);
+
+    return keys;
+});
+
 Handlebars.registerHelper('ne', function(a, b) {
     return a !== b;
 });

--- a/DSL/DataMapper/views/training/extract_slot_keys.hbs
+++ b/DSL/DataMapper/views/training/extract_slot_keys.hbs
@@ -1,0 +1,9 @@
+{
+"slots": [
+{{#each hits}}
+    {{#each (extractSlotKeys _source.slots)}}
+        {"id":"{{this}}","name":"{{this}}"}{{#unless @last}},{{/unless}}
+    {{/each}}{{#unless @last}},{{/unless}}
+{{/each}}
+]
+}

--- a/DSL/DataMapper/views/training/get_intent_and_id.hbs
+++ b/DSL/DataMapper/views/training/get_intent_and_id.hbs
@@ -1,0 +1,8 @@
+{
+"intents": [
+{{#each hits}}
+    {"intent":"{{_source.intent}}",
+    "id":"{{_source.intent}}"}{{#unless @last}},{{/unless}}
+{{/each}}
+]
+}

--- a/DSL/DataMapper/views/training/get_slot_details.hbs
+++ b/DSL/DataMapper/views/training/get_slot_details.hbs
@@ -1,0 +1,22 @@
+{
+    "name":"common_teenus_ilm_asukoht",
+    "type":"text",
+    "influence_conversation":true,
+"mappings": [
+{
+"type": "from_entity",
+"entity": "asukoht",
+"intent": "common_teenus_ilm"
+},
+{
+"type": "from_entity",
+"entity": "asukoht",
+"intent": "nlu_fallback"
+},
+{
+"type": "from_entity",
+"entity": "asukoht",
+"intent": "rahvaarv"
+}
+]
+}

--- a/DSL/Ruuter.private/GET/rasa/intent-and-id.yml
+++ b/DSL/Ruuter.private/GET/rasa/intent-and-id.yml
@@ -1,0 +1,19 @@
+getIntents:
+  call: http.get
+  args:
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/intents/_search?size=10000"
+  result: getIntentsResult
+
+mapIntentsData:
+  call: http.post
+  args:
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-intent-and-id"
+    body:
+      hits: ${getIntentsResult.response.body.hits.hits}
+  result: intentsData
+  next: returnSuccess
+
+returnSuccess:
+  return: ${intentsData.response.body.data.intents}
+  wrapper: false
+  next: end

--- a/DSL/Ruuter.private/GET/rasa/slots.yml
+++ b/DSL/Ruuter.private/GET/rasa/slots.yml
@@ -1,7 +1,11 @@
 getSlots:
   call: http.get
   args:
-    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/slots/_search?size=10000"
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/domain/_search?pretty=true"
+    body:
+      query:
+        match:
+          _id: "slots"
   result: getSlotsResult
 
 mapSlotsData:

--- a/DSL/Ruuter.private/GET/rasa/slots.yml
+++ b/DSL/Ruuter.private/GET/rasa/slots.yml
@@ -1,17 +1,17 @@
 getSlots:
-  call: http.get
+  call: http.post
   args:
     url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/domain/_search?pretty=true"
     body:
       query:
         match:
-          _id: "slots"
+          _id: 'slots'
   result: getSlotsResult
 
 mapSlotsData:
   call: http.post
   args:
-    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-slots"
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/extract-slot-keys"
     body:
       hits: ${getSlotsResult.response.body.hits.hits}
   result: slotsData

--- a/DSL/Ruuter.private/GET/rasa/slots/byId.yml
+++ b/DSL/Ruuter.private/GET/rasa/slots/byId.yml
@@ -1,0 +1,35 @@
+assign_values:
+  assign:
+    parameters: ${incoming.body}
+
+getSlots:
+  call: http.post
+  args:
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/domain/_search?pretty=true"
+    body:
+      query:
+        match:
+          _id: 'slots'
+  result: getSlotsResult
+
+mapSlotsData:
+  call: http.post
+  args:
+    url: "[#TRAINING_DMAPPER]:[#TRAINING_DMAPPER_PORT]/dmapper/get-slot-details"
+    body:
+      hits: "g"
+  result: slotsData
+  next: returnSuccess
+
+returnSuccess:
+  return: ${slotsData.response.body.data}
+  wrapper: false
+  next: end
+
+returnUnauthorized:
+  return: "error: unauthorized"
+  next: end
+
+returnNotFount:
+  return: "ERROR: slot not found"
+  next: end

--- a/GUI/src/pages/Training/Slots/SlotsDetail.tsx
+++ b/GUI/src/pages/Training/Slots/SlotsDetail.tsx
@@ -36,7 +36,7 @@ const SlotsDetail: FC<SlotsDetailProps> = ({ mode }) => {
   const queryClient = useQueryClient();
   const [selectedSlotType, setSelectedSlotType] = useState<string | null>(null);
   const { data: slot } = useQuery<Slot>({
-    queryKey: [`slots/${params.id}`],
+    queryKey: [`slots/byId`],
     enabled: mode === 'edit' && !!params.id,
   });
   const { data: intents } = useQuery<Intent[]>({
@@ -46,16 +46,17 @@ const SlotsDetail: FC<SlotsDetailProps> = ({ mode }) => {
     queryKey: ['entities'],
   });
 
-  const { register, control, handleSubmit, reset } = useForm<SlotCreateDTO>({
+  const { register, control, handleSubmit, reset, setValue } = useForm<SlotCreateDTO>({
     mode: 'onChange',
     shouldUnregister: true,
   });
-
   useEffect(() => {
     if (slot) {
+      setValue('type', slot.type)
+      setSelectedSlotType(slot.type)
       reset(slot);
     }
-  }, [reset, slot]);
+  }, [reset, slot, setValue]);
 
   const newSlotMutation = useMutation({
     mutationFn: (data: SlotCreateDTO) => createSlot(data),
@@ -114,13 +115,14 @@ const SlotsDetail: FC<SlotsDetailProps> = ({ mode }) => {
         <h1>{t('training.slots.titleOne')}</h1>
         <Button onClick={handleSlotSave} style={{ marginLeft: 'auto' }}>{t('global.save')}</Button>
       </Track>
-
       <Card>
         <Track direction='vertical' align='left' gap={8}>
           <FormInput {...register('name')} label={t('training.slots.slotName')} />
           <Controller name='type' control={control} render={({ field }) =>
             <FormSelect
               {...field}
+              onLoad={() => field.onChange(slot?.type)}
+              defaultValue={slot?.type}
               label={t('training.slots.slotType')}
               options={slotTypes}
               onSelectionChange={(selection) => {
@@ -132,12 +134,12 @@ const SlotsDetail: FC<SlotsDetailProps> = ({ mode }) => {
           <Controller name='influenceConversation' control={control} render={({ field }) =>
             <Switch
               {...field}
+              defaultChecked={slot?.influenceConversation}
               label={t('training.slots.influenceConversation')}
             />
           } />
         </Track>
       </Card>
-
       {selectedSlotType && (
         <Card header={
           <h2 className='h5'>{t('training.slots.mapping')}</h2>

--- a/GUI/src/pages/Training/Slots/SlotsDetail.tsx
+++ b/GUI/src/pages/Training/Slots/SlotsDetail.tsx
@@ -40,7 +40,7 @@ const SlotsDetail: FC<SlotsDetailProps> = ({ mode }) => {
     enabled: mode === 'edit' && !!params.id,
   });
   const { data: intents } = useQuery<Intent[]>({
-    queryKey: ['intents'],
+    queryKey: ['intent-and-id'],
   });
   const { data: entities } = useQuery<Entity[]>({
     queryKey: ['entities'],


### PR DESCRIPTION
- Updated GET/rasa/slots dsl to get properly retireve slots from domain file.
- Added new mapping to properly display slots on GUI side
- Added new dsl to get SLOT detailed view by id
- Added mapper for slot detailed view
- Properly fills first form with slot information
- Added new DSL to get intents and id's (intent:intent,id:intent)
- Added new mapper intent-and-id for SLOT detailed view.
- Updated SlotDetails components to use new DSL and mapper.

This PR includes changes to make SLOT page work.Also since there were no specific task for SlotDetail view in the epic #14,this part is developed within this PR.