### PR TITLE
Entities (FIX)

### DIFF
--- a/DSL/DataMapper/views/training/get_entities.hbs
+++ b/DSL/DataMapper/views/training/get_entities.hbs
@@ -1,12 +1,13 @@
 {
     "entities": [
     {{#each hits}}
-        {{#if (eq this._index "entities") }}
-            {
-              "id": "{{ this._id }}",
-              "name": "{{ this._source.entity }}"
-            }
-            {{#unless @last}},{{/unless}}
+        {{#if (eq this._id "entities") }}
+            {{#each this._source.entities}}
+                {
+                    "id": "{{ this }}",
+                    "name": "{{ this }}"
+                }{{#unless @last}},{{/unless}}
+            {{/each}}
         {{/if}}
     {{/each}}
     ]

--- a/DSL/Ruuter.private/GET/rasa/entities.yml
+++ b/DSL/Ruuter.private/GET/rasa/entities.yml
@@ -1,7 +1,7 @@
 getEntities:
   call: http.get
   args:
-    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/entities/_search?size=10000"
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/domain/_search?size=10000"
   result: getEntitiesResult
 
 mapEntitiesData:

--- a/GUI/src/pages/Training/IntentsFollowupTraining/Entities.tsx
+++ b/GUI/src/pages/Training/IntentsFollowupTraining/Entities.tsx
@@ -25,8 +25,8 @@ const Entities: FC = () => {
   } | null>(null);
   const [deletableRow, setDeletableRow] = useState<string | number | null>(null);
   const [newEntityFormOpen, setNewEntityFormOpen] = useState(false);
-  const { data: entities } = useQuery<Entity[]>({
-    queryKey: ['entities'],
+  const { data: entities, refetch } = useQuery<Entity[]>({
+    queryKey: ['entities']
   });
   const { register, handleSubmit } = useForm<{ entity: string }>();
 
@@ -40,6 +40,7 @@ const Entities: FC = () => {
     mutationFn: (data: { entity: string }) => addEntity(data),
     onSuccess: async () => {
       await queryClient.invalidateQueries(['entities']);
+      refetch();
       toast.open({
         type: 'success',
         title: t('global.notification'),
@@ -60,6 +61,7 @@ const Entities: FC = () => {
     mutationFn: ({ data }: { data: { entity_name: string, entity: string, intent: string } }) => editEntity(data),
     onSuccess: async () => {
       await queryClient.invalidateQueries(['entities']);
+      refetch();
       toast.open({
         type: 'success',
         title: t('global.notification'),
@@ -80,6 +82,7 @@ const Entities: FC = () => {
     mutationFn: (entityData: { entity_name: string | number }) => deleteEntity(entityData),
     onSuccess: async () => {
       await queryClient.invalidateQueries(['entities']);
+      refetch();
       toast.open({
         type: 'success',
         title: t('global.notification'),


### PR DESCRIPTION
- Reverted /GET/entities dsl to use domain instead of entities
- Reverted get_entities mapper
- Updated Entities.tsx to refetch entities whenever it has any changes (add/update/delete)

It fixed displaying part.
Adding new entity locally works but when deployed there is different response for one of the steps, currently investigating.

Update: Looks like it was caused by Guard, now after recent Kaspar change request is working.