### PR TITLE
Response Page and DataMapper Fixes

### DIFF
--- a/DSL/DataMapper/js/file/deleteIntentFile.js
+++ b/DSL/DataMapper/js/file/deleteIntentFile.js
@@ -21,7 +21,7 @@ router.post('/', (req, res) => {
         return res.status(400).json({
             error: true,
             message: 'File path contains illegal characters',
-        }).send("File path contains illegal characters");
+        });
     }
 
     fs.unlink(deletePath, (err) => {
@@ -29,13 +29,13 @@ router.post('/', (req, res) => {
             return res.status(500).json({
                 error: true,
                 message: 'Unable to delete file',
-            }).send("Error deleting file");
+            });
         }
 
         return res.status(200).json({
             error: false,
             message: 'File deleted successfully',
-        }).send("Success deleting file");
+        });
     });
 });
 

--- a/DSL/DataMapper/js/file/fileRead.js
+++ b/DSL/DataMapper/js/file/fileRead.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import fs from 'fs';
 import mime from 'mime-types';
+
 const router = express.Router();
 
 router.post('/', (req, res) => {
@@ -15,23 +16,24 @@ router.post('/', (req, res) => {
         res.status(400).send('Relative paths are not allowed');
         return;
     }
-    const mimeType = mime.lookup(file_path);
-    const name = file_path.split(/(\\|\/)/g).pop();
 
     fs.readFile(file_path, 'utf-8', (err, data) => {
         if (err) {
             res.status(404).send('File not found');
             return;
         }
-        const file = Buffer.from(data).toString('base64');
 
-        res.setHeader('Content-Type', 'application/json');
+        const mimeType = mime.lookup(file_path);
+        const name = file_path.split(/(\\|\/)/g).pop();
+        const file = Buffer.from(data).toString('base64');
 
         const result = {
             name: name,
             file: file,
             mimeType: mimeType
         };
+
+        res.setHeader('Content-Type', 'application/json');
         res.json(result);
     });
 });

--- a/DSL/Ruuter.private/GET/rasa/responses.yml
+++ b/DSL/Ruuter.private/GET/rasa/responses.yml
@@ -1,7 +1,7 @@
 getResponses:
   call: http.get
   args:
-    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/responses/_search?size=10000"
+    url: "[#TRAINING_OPENSEARCH]:[#TRAINING_OPENSEARCH_PORT]/domain/_search?size=10000"
   result: getResponsesResult
 
 mapResponsesData:
@@ -16,8 +16,4 @@ mapResponsesData:
 returnSuccess:
   return: ${responsesData.response.body.data.responses}
   wrapper: false
-  next: end
-
-returnUnauthorized:
-  return: "error: unauthorized"
   next: end

--- a/GUI/src/pages/Training/Responses/index.tsx
+++ b/GUI/src/pages/Training/Responses/index.tsx
@@ -36,11 +36,18 @@ const Responses: FC = () => {
   const { register, handleSubmit } = useForm<NewResponse>();
 //  const [editingTrainingTitle, setEditingTrainingTitle] = useState<string>("");
   let editingTrainingTitle: string;
-  const formattedResponses = useMemo(() => responses ? responses.response.map((r, i) => ({
-    id: i,
-    response: r.name,
-    text: r.response[0].text,
-  })) : [], [responses]);
+  const formattedResponses = useMemo(() => {
+    if (responses && responses.response) {
+      return responses.response.map((r, i) => ({
+        id: i,
+        response: r.name,
+        text: r.response[0].text,
+      }));
+    } else {
+      return [];
+    }
+  }, [responses]);
+
 
   useDocumentEscapeListener(() => setEditableRow(null));
 


### PR DESCRIPTION
This PR fixes the opening crash of the response page as well as a few problems that DataMapper endured when clicking around intents and common intents pages in the TEST environment. Finally found the reading bug that happened when editing things, with DataMapper fixing headers into requests after the request had been formed (.json and .sent consecutively in Express). The bug in response page had to do with the case of an empty or failing response from the API. 