### PR TITLE
97 - List all Rasa Stories By Slot Form or Response

### DIFF
--- a/DSL/Ruuter.private/GET/rasa/stories.yml
+++ b/DSL/Ruuter.private/GET/rasa/stories.yml
@@ -1,7 +1,7 @@
 getStories:
   call: http.get
   args:
-    url: "[#TRAINING_OPENSEARCH]/stories/_search?size=10000"
+    url: "[#TRAINING_OPENSEARCH]/stories/_search?size=1000"
   result: getStoriesResult
 
 mapStoriesData:

--- a/DSL/Ruuter.private/POST/rasa/stories/search.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/search.yml
@@ -8,29 +8,68 @@ checkForIncomingType:
   switch:
     - condition: ${type == "responses"}
       next: getStoriesSearchForResponses
-#    - condition: ${type == "forms"}
-#      next: getStoriesSearchForForms
-#    - condition: ${type == "slots"}
-#      next: getStoriesSearchForSlots
-#    - condition: ${type === undefined}
-#      next: getStoriesSearch
+    - condition: ${type == "forms"}
+      next: getStoriesSearchForForms
+    - condition: ${type == "slots"}
+      next: getStoriesSearchForSlots
+
+getStoriesSearch:
+  call: http.get
+  args:
+    url: "[#TRAINING_PUBLIC_RUUTER]/rasa/stories"
+  result: getStoriesResult
+  next: returnNoSearchSpecified
 
 getStoriesSearchForResponses:
   call: http.post
   args:
     url: "[#TRAINING_OPENSEARCH]/stories/_search/template"
     body:
-      id: ${"story-with-" + value}
+      id: ${"story-with-" + type}
       params:
-        actionOrActiveLoopValue: ${value}
+        searchField: ${value}
       source:
         query:
           bool:
             should:
               - match:
-                  steps.action: ${value}
+                  steps.action: "{{searchField}}"
               - match:
-                  steps.active_loop: ${value}
+                  steps.active_loop: "{{searchField}}"
+  result: getStoriesResult
+  next: mapStoriesData
+
+getStoriesSearchForForms:
+  call: http.post
+  args:
+    url: "[#TRAINING_OPENSEARCH]/stories/_search/template"
+    body:
+      id: ${"story-with-" + type}
+      params:
+        searchField: ${value}
+      source:
+        query:
+          bool:
+            should:
+              - match:
+                  steps.action: "{{searchField}}"
+  result: getStoriesResult
+  next: mapStoriesData
+
+getStoriesSearchForSlots:
+  call: http.post
+  args:
+    url: "[#TRAINING_OPENSEARCH]/stories/_search/template"
+    body:
+      id: ${"story-with-" + type}
+      params:
+        searchField: ${value}
+      source:
+        query:
+          bool:
+            must:
+              - exists:
+                  field: "steps.slot_was_set.{{searchField}}"
   result: getStoriesResult
 
 mapStoriesData:
@@ -43,5 +82,9 @@ mapStoriesData:
   next: returnSuccess
 
 returnSuccess:
-  return: ${storiesData.response.body}
+  return: ${storiesData.response.body.data.stories}
+  next: end
+
+returnNoSearchSpecified:
+  return: ${getStoriesResult.response.body.response}
   next: end


### PR DESCRIPTION
For issue: https://github.com/buerokratt/Training-Module/issues/97

This PR fixes and finalizes the story search requests. The story search is into OpenSearch is made with specific request bodies that will search through the content of the story for any specified Slot, Form, or Response, and will return the stories in which the input data was found.

In case of faulty data or no data at all, there is a fallback option in which all stories are returned.

It is important for the /rasa/stories/search POST endpoint to receive a request body with the "type" and "value" fields. Type is the type of data you're looking for (slot,form,response,any) and value is the title for which the search is conducted. For example:

```
{
    "type": "slots",
    "value": "asukoht"
}
```

```
{
    "type": "forms",
    "value": "custom_fallback_form"
}
```

Postman set-up and returns for any type of data requested:


![Postman_U0TOzmG61o](https://github.com/buerokratt/Training-Module/assets/31955511/b339fa36-b5eb-4db9-be7f-f249c40271d7)
![Postman_VIq67lzekZ](https://github.com/buerokratt/Training-Module/assets/31955511/8aa19ecc-4d33-4d7a-9074-2e84935ebe9c)
![Postman_WTFwFiCgGe](https://github.com/buerokratt/Training-Module/assets/31955511/938a2348-70f9-471c-87b2-e2f20c43b53b)
![Postman_OORqwbG3WW](https://github.com/buerokratt/Training-Module/assets/31955511/1ce8fd14-8903-49bd-a3f9-cebf9b0c242b)

