### PR TITLE
74 & 79 - Examples Bugs on Intents Page

### DIFF
--- a/DSL/Ruuter.private/GET/rasa/intents/intents-full.yml
+++ b/DSL/Ruuter.private/GET/rasa/intents/intents-full.yml
@@ -20,14 +20,6 @@ getDomainFile:
       cookie: ${incoming.headers.cookie}
   result: getDomainDataResult
 
-getIntentsExampleCount:
-  call: http.post
-  args:
-    url: "[#TRAINING_OPENSEARCH]/intents/_search/template"
-    body:
-      id: "intents-with-examples-count"
-  result: getIntentCountResult
-
 checkIfIntentsExists:
   switch:
     - condition: ${getIntentDataResult.response.body.data.intents != null}
@@ -39,7 +31,6 @@ assignResults:
     intents:
       intents: ${getIntentDataResult.response.body.data.intents}
       inmodel: ${getDomainDataResult.response.body.response.intents}
-      count: ${getIntentCountResult.response.body.aggregations.hot.buckets}
 
 mapIntentsData:
   call: http.post
@@ -56,4 +47,6 @@ returnSuccess:
 
 returnNoIntentsFound:
   return: "Error: no intents found"
+  wrapper: false
+  status: 409
   next: end

--- a/DSL/Ruuter.private/POST/rasa/intents/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/add.yml
@@ -91,15 +91,18 @@ returnSuccess:
 
 returnTooShortError:
   status: 409
+  wrapper: false
   return: "Intent name is too short"
   next: end
 
 returnIntentExists:
   status: 409
+  wrapper: false
   return: "Intent with that name already exists"
   next: end
 
 returnIntentsError:
   status: 409
+  wrapper: false
   return: "Intents parsing error"
   next: end

--- a/DSL/Ruuter.private/POST/rasa/intents/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/delete.yml
@@ -279,28 +279,36 @@ returnSuccess:
 
 returnTooShortError:
   return: "Intent name is too short"
+  wrapper: false
+  status: 409
   next: end
 
 returnIntentExists:
   return: "Intent with that name already exists"
+  wrapper: false
+  status: 409
   next: end
 
 returnIntentMissing:
   return: "Intent to update is missing"
+  wrapper: false
+  status: 409
   next: end
 
 returnIntentFileMissing:
   return: "Intent file to update is missing"
+  wrapper: false
+  status: 409
   next: end
 
 returnRuleDependency:
   return: "Intent has dependency with rules"
+  wrapper: false
+  status: 409
   next: end
 
 returnStoriesDependency:
   return: "Intent has dependency with stories"
-  next: end
-
-returnUnauthorized:
-  return: "error: unauthorized"
+  wrapper: false
+  status: 409
   next: end

--- a/DSL/Ruuter.private/POST/rasa/intents/download.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/download.yml
@@ -71,8 +71,12 @@ returnSuccess:
 
 returnIntentFileMissing:
   return: "Intent file is missing"
+  wrapper: false
+  status: 409
   next: end
 
 returnIntentExamplesMissing:
   return: "Intent has no examples"
+  wrapper: false
+  status: 409
   next: end

--- a/GUI/src/pages/Training/Intents/index.tsx
+++ b/GUI/src/pages/Training/Intents/index.tsx
@@ -41,7 +41,7 @@ const Intents: FC = () => {
     Intent | null
   >(null);
 
-  const { data: intentsFullResponse, isLoading } = useQuery({
+  const { data: intentsFullResponse, isLoading, refetch } = useQuery({
     queryKey: ['intents/intents-full'],
   });
 
@@ -94,6 +94,11 @@ const Intents: FC = () => {
     return !isNaN(date.getTime());
   }
 
+  const updateSelectedIntent = (updatedIntent: Intent) => {
+    setSelectedIntent(null);
+    setTimeout(() => setSelectedIntent(updatedIntent), 20);
+  };
+
   useEffect(() => {
     const queryIntentName = searchParams.get('intent');
     if (intents && queryIntentName) {
@@ -139,9 +144,10 @@ const Intents: FC = () => {
     mutationFn: (data: { name: string }) => deleteIntent(data),
     onMutate: () => {
       setRefreshing(true);
-      setDeletableIntent(null) },
+      setDeletableIntent(null);
+      setSelectedIntent(null);
+      setSelectedTab(null); },
     onSuccess: async () => {
-      setSelectedIntent(null)
       queryRefresh(null);
       setRefreshing(false);
       toast.open({
@@ -359,7 +365,7 @@ const Intents: FC = () => {
     addExamplesMutation.mutate({
         intentName: selectedIntent.intent,
         intentExamples: selectedIntent.examples,
-        newExamples: example
+        newExamples: example.trim()
     });
   };
 
@@ -421,7 +427,7 @@ const Intents: FC = () => {
                   hideLabel
                 />
                 <Button
-                  onClick={() => newIntentMutation.mutate({ name: filter })}
+                  onClick={() => newIntentMutation.mutate({ name: filter.trim() })}
                   disabled={!filter}
                 >
                   {t('global.add')}
@@ -588,6 +594,7 @@ const Intents: FC = () => {
                     entities={entities ?? []}
                     selectedIntent={selectedIntent}
                     queryRefresh={queryRefresh}
+                    updateSelectedIntent={updateSelectedIntent}
                   />
                 )}
               </div>


### PR DESCRIPTION
This PR solves the bugs mentioned in: 

https://github.com/buerokratt/Training-Module/issues/74
https://github.com/buerokratt/Training-Module/issues/79

**Fixes tried**: On the successful return of the update or deletion query (onSuccess block), a variety of options to try and timeout the query completion and force it past the re-render of the page, forceful cancellation and re-rendering of all the data queries through component reference and also in the QueryClient, attempting to trigger an update of the component's data through parent component. Still, with the current structure of the page, the updated information was only displayed on a full manual refresh due to the opened tab.

**Currently**, the fix is to display an optimistic update on the page once the query is completed successfully. The titles and the examples are simple strings, so it does not make a difference for the end user as the queries work identically in both cases and identical data is also displayed in the case of a full page refresh.