### PR TITLE
#88 Rest Update rasa slot

### DIFF
--- a/DSL/Ruuter.private/POST/rasa/slots/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/slots/add.yml
@@ -73,9 +73,6 @@ returnSuccess:
 
 returnSlotExists:
   return: "Slot exists"
+  wrapper: false
   status: 409
-  next: end
-
-returnUnauthorized:
-  return: "error: unauthorized"
   next: end

--- a/DSL/Ruuter.private/POST/rasa/slots/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/slots/delete.yml
@@ -123,20 +123,24 @@ returnSuccess:
 
 returnSlotIsMissing:
   return: "Can't find slot to delete"
+  wrapper: false
+  status: 409
   next: end
 
 returnSlotHasDependencyToForms:
   return: "Deleting a slot is forbidden because it has relation to forms"
+  wrapper: false
+  status: 409
   next: end
 
 returnSlotHasDependencyToRules:
   return: "Deleting a slot is forbidden because it has relation to rules"
+  wrapper: false
+  status: 409
   next: end
 
 returnSlotHasDependencyToStories:
   return: "Deleting a slot is forbidden because it has relation to stories"
-  next: end
-
-returnUnauthorized:
-  return: "error: unauthorized"
+  wrapper: false
+  status: 409
   next: end

--- a/DSL/Ruuter.private/POST/rasa/slots/slotById.yml
+++ b/DSL/Ruuter.private/POST/rasa/slots/slotById.yml
@@ -43,10 +43,8 @@ returnSuccess:
   wrapper: false
   next: end
 
-returnUnauthorized:
-  return: "error: unauthorized"
-  next: end
-
 returnNotFound:
   return: "ERROR: slot not found"
+  wrapper: false
+  status: 409
   next: end

--- a/DSL/Ruuter.private/POST/rasa/slots/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/slots/update.yml
@@ -78,8 +78,6 @@ returnSuccess:
 
 returnSlotIsMissing:
   return: "Can't find slot to update"
-  next: end
-
-returnUnauthorized:
-  return: "error: unauthorized"
+  wrapper: false
+  status: 409
   next: end

--- a/GUI/src/pages/Training/Slots/index.tsx
+++ b/GUI/src/pages/Training/Slots/index.tsx
@@ -25,6 +25,7 @@ const Slots: FC = () => {
   useEffect(() => {
     refetch()
   }, [slots,refetch]);
+  setTimeout(() => refetch(), 300);
 
   const deleteSlotMutation = useMutation({
     mutationFn: ({ id }: { id: string | number }) => deleteSlot(id),


### PR DESCRIPTION
- Added wrapper/status 409 to faulty responses in add dsl
- Added wrapper/status 409 to faulty responses in update dsl
- Added wrapper/status 409 to faulty responses in delete dsl
- Added refetching in slots page , this would update GUI after SLOT was updated

Related [task](https://github.com/buerokratt/Training-Module/issues/88).