### PR TITLE
115 - Story Update YML, bug fixes

### DIFF
--- a/DSL/DataMapper/js/convert/jsonToYamlStories.js
+++ b/DSL/DataMapper/js/convert/jsonToYamlStories.js
@@ -14,7 +14,7 @@ router.post('/', multer().array('file'), async (req, res) => {
                     case !!step.intent:
                         formattedStep.intent = step.intent;
                         break;
-                    case !!step.entities:
+                    case !!step.entities && step.entities.length > 0:
                         formattedStep.entities = step.entities;
                         break;
                     case !!step.action:
@@ -34,7 +34,16 @@ router.post('/', multer().array('file'), async (req, res) => {
         })).filter(entry => entry.steps.length > 0),
     };
 
-    const yamlString = yaml.stringify(result);
+    const yamlString = yaml.stringify(result, {
+        customTags: [
+            {
+                tag: 'tag:yaml.org,2002:seq',
+                format: 'flow',
+                test: (value) => value && value.length === 0,
+                resolve: () => ''
+            }
+        ]
+    });
 
     res.json({ "json": yamlString });
 });

--- a/DSL/DataMapper/js/util/objectListContainsId.js
+++ b/DSL/DataMapper/js/util/objectListContainsId.js
@@ -1,0 +1,20 @@
+import express from 'express';
+
+const router = express.Router();
+
+router.post('/', (req, res) => {
+    const { id, list } = req.body;
+    const exists = checkIdExists(list, id);
+    res.json(exists);
+});
+
+function checkIdExists(array, id) {
+    for (let i = 0; i < array.length; i++) {
+        if (array[i].id === id) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export default router;

--- a/DSL/DataMapper/server.js
+++ b/DSL/DataMapper/server.js
@@ -39,6 +39,7 @@ import stringReplace from "./js/util/stringReplace.js";
 import removeRulesByIntentName from "./js/util/removeRulesByIntentName.js";
 import domainUpdateExistingResponse from "./js/util/domainUpdateExistingResponse.js";
 import replaceKeyValueObj from "./js/util/updateKeyValueObj.js";
+import objectListContainsId from "./js/util/objectListContainsId.js";
 import validateStories from "./js/validation/validateStories.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -75,6 +76,7 @@ app.use('/convert/string/replace', stringReplace)
 app.use('/convert/string/toArray', stringToArray)
 app.use('/rules/remove-by-intent-name', removeRulesByIntentName);
 app.use('/domain/update-existing-response', domainUpdateExistingResponse)
+app.use('/util/objectListContainsId', objectListContainsId)
 app.use('/validate/validate-stories', validateStories)
 app.use(express.urlencoded({ extended: true }));
 

--- a/DSL/Ruuter.private/POST/rasa/stories/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/add.yml
@@ -65,10 +65,6 @@ mergeStories:
       iteratee: "story"
   result: mergedStories
 
-#checkMerged:
-#  return: ${mergedStories.response.body}
-#  next: end
-
 convertJsonToYaml:
   call: http.post
   args:

--- a/DSL/Ruuter.private/POST/rasa/stories/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/update.yml
@@ -3,21 +3,40 @@ assign_values:
     id: ${incoming.body.id}
     storyData: ${incoming.body.data}
 
-getStoriesWithName:
+validateStoriesForDuplicates:
   call: http.post
+  args:
+    url: "[#TRAINING_DMAPPER]/validate/validate-stories"
+    body:
+      story: ${storyData}
+  result: validateStoriesResult
+
+validateStoriesCheck:
+  switch:
+      - condition: ${validateStoriesResult.response.body.result == true}
+        next: returnDuplicateIntentOrEntity
+  next: returnStoryIsMissing
+
+getStoriesWithName:
+  call: http.get
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]/rasa/stories"
     headers:
       cookie: ${incoming.headers.cookie}
-    body:
-      story: ${id}
   result: storiesResult
+
+checkIfStoryExists:
+  call: http.post
+  args:
+    url: "[#TRAINING_DMAPPER]/util/objectListContainsId"
+    body:
+      id: ${storyData.story}
+      list: ${storiesResult.response.body.response}
+  result: storiesCheckResult
 
 validateStories:
   switch:
-    - condition: ${storiesResult.response.body.response.story != id}
-      next: returnStoryIsMissing
-    - condition: ${storyData.story != id && storiesResult.response.body.response.story == storyData.story}
+    - condition: ${storiesCheckResult.response.body.result == false}
       next: returnStoryExists
   next: getFileLocations
 
@@ -67,7 +86,7 @@ mergeStories:
 convertJsonToYaml:
   call: http.post
   args:
-    url: "[#TRAINING_DMAPPER]/convert/json-to-yaml"
+    url: "[#TRAINING_DMAPPER]/convert/json-to-yaml-stories"
     body:
       version: "3.0"
       stories: ${mergedStories.response.body}
@@ -83,18 +102,19 @@ saveStoriesFile:
   result: fileResult
 
 deleteOldOpenSearchEntry:
-  call: http.delete
-  args:
-    url: "[#TRAINING_OPENSEARCH]/stories/_doc/${storiesResult.response.body.response.id}"
-  result: updateSearchResult
-
-addNewOpenSearchEntry:
   call: http.post
   args:
-    url: "[#TRAINING_OPENSEARCH]/stories/_doc"
+    url: "[#TRAINING_PIPELINE]/delete/object/stories"
     body:
-      story: ${storyData.story}
-      steps: ${storyData.steps}
+      id: ${id}
+  result: deleteSearchResult
+
+updateOpenSearch:
+  call: http.post
+  args:
+    url: "[#TRAINING_PIPELINE]/bulk/stories/story"
+    body:
+      input: ${storiesYaml.response.body.json}
   result: updateSearchResult
   next: returnSuccess
 
@@ -110,3 +130,9 @@ returnStoryExists:
   return: "Story exists"
   status: 409
   next: end
+
+returnDuplicateIntentOrEntity:
+  return: "Story may not have duplicate consecutive intents or entities"
+  status: 406
+  next: end
+

--- a/GUI/src/pages/Training/Stories/StoriesDetail.tsx
+++ b/GUI/src/pages/Training/Stories/StoriesDetail.tsx
@@ -79,7 +79,7 @@ const StoriesDetail: FC<{ mode: 'new' | 'edit' }> = ({ mode }) => {
   const category = locationState?.category || 'stories';
   const storyTitle = locationState?.storyTitle || null;
 
-  const { data: storyData, isLoading, refetch } = useQuery<Story>({
+  const { data: storyData, refetch } = useQuery<Story>({
     queryKey: ['story-by-name', storyId],
     enabled: category === 'stories' && !!storyId,
   });
@@ -136,8 +136,10 @@ const StoriesDetail: FC<{ mode: 'new' | 'edit' }> = ({ mode }) => {
   });
 
   const editStoryMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string | number, data: StoryDTO }) => editStory(id, data),
-    onMutate: () => setRefreshing(true),
+    mutationFn: ({ id, data }: { id: string, data: StoryDTO }) => editStory(id, data),
+    onMutate: () => {
+      setRefreshing(true)
+    },
     onSuccess: async () => {
       await queryClient.invalidateQueries(['stories']);
       toast.open({
@@ -166,7 +168,7 @@ const StoriesDetail: FC<{ mode: 'new' | 'edit' }> = ({ mode }) => {
         title: t('global.notification'),
         message: 'Intent deleted',
       });
-      navigate(import.meta.env.BASE_URL + 'treening/treening/kasutuslood');
+      navigate(import.meta.env.BASE_URL + 'treening/treening/stories');
     },
     onError: (error: AxiosError) => {
       toast.open({
@@ -247,7 +249,7 @@ const StoriesDetail: FC<{ mode: 'new' | 'edit' }> = ({ mode }) => {
       addOutputNode();
     }
 
-    if (!editableTitle || editableTitle === '') {
+    if ((!title || title === '') && (!editableTitle || editableTitle === '')) {
       toast.open({
         type: 'error',
         title: t('global.notificationError'),
@@ -284,7 +286,7 @@ const StoriesDetail: FC<{ mode: 'new' | 'edit' }> = ({ mode }) => {
     await refetch();
     const updatedStoryData  = refetch();
     updatedStoryData.then((storyOrRuleObject) => {
-      if (storyOrRuleObject.data.story != null && storyOrRuleObject.data.story === editableTitle) {
+      if (mode === 'new' && (storyOrRuleObject.data.story != null && storyOrRuleObject.data.story === editableTitle)) {
         setRefreshing(false);
       } else {
         setTimeout(() => {


### PR DESCRIPTION
This PR fixes several issues in the task: https://github.com/buerokratt/Training-Module/issues/115

In the case of no data mismatch, the editing page should now correctly open the story as well as proceed with all necessary checks in saving the nodes. Also fixed is the title editing and saving as well as removing the old story from OpenSearch through the pipeline and saving any new changes made. 