### PR TITLE
114 & 115 - Update Story and Rule Fixes

### DIFF
--- a/DSL/DataMapper/js/convert/jsonToYamlStories.js
+++ b/DSL/DataMapper/js/convert/jsonToYamlStories.js
@@ -19,7 +19,7 @@ router.post('/', multer().array('file'), async (req, res) => {
                         case !!step.intent:
                             formattedStep.intent = step.intent;
                             break;
-                        case !!step.entities && step.entities.length > 0:
+                        case !!step.entities:
                             formattedStep.entities = step.entities;
                             break;
                         case !!step.action:
@@ -49,7 +49,7 @@ router.post('/', multer().array('file'), async (req, res) => {
                         case !!step.intent:
                             formattedStep.intent = step.intent;
                             break;
-                        case !!step.entities && step.entities.length > 0:
+                        case !!step.entities:
                             formattedStep.entities = step.entities;
                             break;
                         case !!step.action:

--- a/DSL/DataMapper/js/validation/validateStoriesRules.js
+++ b/DSL/DataMapper/js/validation/validateStoriesRules.js
@@ -2,22 +2,21 @@ import express from 'express';
 
 const router = express.Router();
 router.post('/', (req, res) => {
-    const steps = req.category === 'rules' ? req.body.rules.steps : req.body.stories.steps;
+    const steps = req.category === 'rules' ? req.body.rule.steps : req.body.story.steps;
     const isValid = validateStepsForNoConsecutiveDuplicates(steps);
     res.json({ result: isValid });
 });
 
 function validateStepsForNoConsecutiveDuplicates(steps) {
-
     for (let i = 1; i < steps.length; i++) {
         const currentStep = steps[i];
         const previousStep = steps[i - 1];
 
         if (currentStep.entities && previousStep.entities && areConsecutive(currentStep, previousStep)) {
-            const currentEntities = currentStep.entities.map(entity => entity.entity);
-            const previousEntities = previousStep.entities.map(entity => entity.entity);
+            const currententities = currentstep.entities.map(entity => entity.entity);
+            const previousentities = previousstep.entities.map(entity => entity.entity);
 
-            if (hasCommonElement(currentEntities, previousEntities)) {
+            if (hascommonelement(currententities, previousentities)) {
                 return false;
             }
         }
@@ -37,7 +36,11 @@ function hasCommonElement(arr1, arr2) {
 }
 
 function areConsecutive(currentStep, previousStep) {
-    return currentStep.start === previousStep.end + 1;
+    if (currentStep.start !== undefined && previousStep.end !== undefined) {
+        return currentStep.start === previousStep.end + 1;
+    }
+
+    return false;
 }
 
 export default router;

--- a/DSL/Ruuter.private/POST/rasa/rules/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/rules/add.yml
@@ -2,21 +2,34 @@ assign_values:
   assign:
     body: ${incoming.body}
 
-getRuleWithName:
+validateRules:
   call: http.post
   args:
-    url: "[#TRAINING_PUBLIC_RUUTER]/rasa/rules"
+    url: "[#TRAINING_DMAPPER]/validate/validate-stories"
+    body:
+      story: ${body}
+      category: "rules"
+  result: validateRulesResult
+
+validateRulesCheck:
+  switch:
+    - condition: ${validateStoriesResult.response.body.result == true}
+      next: getRuleNames
+  next: returnDuplicateIntentOrEntity
+
+getRuleNames:
+  call: http.post
+  args:
+    url: "[#TRAINING_PUBLIC_RUUTER]/rasa/rule-names"
     headers:
       cookie: ${incoming.headers.cookie}
-    body:
-      rule: ${body.rule}
   result: ruleResult
 
-validateRules:
+validateRuleName:
   switch:
-    - condition: ${ruleResult.response.body.response.data.rule != body.rule}
+    - condition: ${!ruleResult.response.body.response.data.names.includes(body.id)}
       next: getFileLocations
-  next: returnRuleExists
+  next: returnStoryExists
 
 getFileLocations:
   call: http.get
@@ -47,7 +60,7 @@ mergeRules:
   args:
     url: "[#TRAINING_DMAPPER]/merge"
     body:
-      array1: ${rulesData.response.body.rules}
+      array1: ${rulesData.response.body.id}
       array2: ${[body]}
       iteratee: "rule"
   result: mergedRules
@@ -87,4 +100,9 @@ returnSuccess:
 returnRuleExists:
   return: "Rule exists"
   status: 409
+  next: end
+
+returnDuplicateIntentOrEntity:
+  return: "Rule may not have duplicate consecutive intents or entities"
+  status: 406
   next: end

--- a/DSL/Ruuter.private/POST/rasa/rules/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/rules/update.yml
@@ -48,7 +48,7 @@ deleteRule:
   args:
     url: "[#TRAINING_DMAPPER]/dmapper/delete-rule"
     body:
-      rules: ${rulesData.response.body.rules}
+      rules: ${rulesData.response.body}
       rule_name: ${body.id}
   result: deleteRulesData
 
@@ -57,7 +57,7 @@ mergeRules:
   args:
     url: "[#TRAINING_DMAPPER]/merge"
     body:
-      array1: ${deleteRulesData.response.body.data}
+      array1: ${deleteRulesData.response.body.data[1]}
       array2: ${[ruleData]}
       iteratee: "rule"
   result: mergedRules
@@ -66,8 +66,9 @@ convertJsonToYaml:
   call: http.post
   args:
     url: "[#TRAINING_DMAPPER]/convert/json-to-yaml-stories"
+    headers:
+      content-type: "application/json"
     body:
-      version: "3.0"
       rules: ${mergedRules.response.body}
   result: rulesYaml
 

--- a/DSL/Ruuter.private/POST/rasa/rules/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/rules/update.yml
@@ -1,6 +1,7 @@
 assign_values:
   assign:
     body: ${incoming.body}
+    ruleData: ${incoming.body.data}
 
 getRuleWithName:
   call: http.post
@@ -9,12 +10,12 @@ getRuleWithName:
     headers:
       cookie: ${incoming.headers.cookie}
     body:
-      rule: ${body.rule}
+      rule: ${body.id}
   result: ruleResult
 
 validateRules:
   switch:
-    - condition: ${ruleResult.response.body.response.data.rule == body.rule}
+    - condition: ${ruleResult.response.body.response.data.rule == body.id}
       next: getFileLocations
   next: returnRulesIsMissing
 
@@ -42,20 +43,29 @@ convertYamlToJson:
       file: ${ruleFile.response.body.file}
   result: rulesData
 
+deleteRule:
+  call: http.post
+  args:
+    url: "[#TRAINING_DMAPPER]/dmapper/delete-rule"
+    body:
+      rules: ${rulesData.response.body.rules}
+      rule_name: ${body.id}
+  result: deleteRulesData
+
 mergeRules:
   call: http.post
   args:
     url: "[#TRAINING_DMAPPER]/merge"
     body:
-      array1: ${rulesData.response.body.rules}
-      array2: ${[body]}
+      array1: ${deleteRulesData.response.body.data}
+      array2: ${[ruleData]}
       iteratee: "rule"
   result: mergedRules
 
 convertJsonToYaml:
   call: http.post
   args:
-    url: "[#TRAINING_DMAPPER]/convert/json-to-yaml"
+    url: "[#TRAINING_DMAPPER]/convert/json-to-yaml-stories"
     body:
       version: "3.0"
       rules: ${mergedRules.response.body}
@@ -70,6 +80,14 @@ saveRulesFile:
       content: ${rulesYaml.response.body.json}
   result: fileResult
   next: updateOpenSearch
+
+deleteOldOpenSearchEntry:
+  call: http.post
+  args:
+    url: "[#TRAINING_PIPELINE]/delete/object/rules"
+    body:
+      id: ${body.id}
+  result: deleteSearchResult
 
 updateOpenSearch:
   call: http.post
@@ -86,4 +104,5 @@ returnSuccess:
 
 returnRulesIsMissing:
   return: "Can't find rule to update"
+  status: 409
   next: end

--- a/DSL/Ruuter.private/POST/rasa/stories/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/add.yml
@@ -1,7 +1,6 @@
 assign_values:
   assign:
     body: ${incoming.body}
-    bodyStringify: ${JSON.stringify(incoming.body)}
 
 validateStories:
   call: http.post
@@ -9,6 +8,7 @@ validateStories:
     url: "[#TRAINING_DMAPPER]/validate/validate-stories"
     body:
       story: ${body}
+      category: "stories"
   result: validateStoriesResult
 
 validateStoriesCheck:

--- a/DSL/Ruuter.private/POST/rasa/stories/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/update.yml
@@ -124,6 +124,7 @@ returnSuccess:
 
 returnStoryIsMissing:
   return: "Can't find story to update"
+  status: 409
   next: end
 
 returnStoryExists:

--- a/DSL/Ruuter.private/POST/rasa/stories/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/update.yml
@@ -6,38 +6,31 @@ assign_values:
 validateStoriesForDuplicates:
   call: http.post
   args:
-    url: "[#TRAINING_DMAPPER]/validate/validate-stories"
+    url: "[#TRAINING_DMAPPER]/validate/validate-stories-rules"
     body:
       story: ${storyData}
   result: validateStoriesResult
 
 validateStoriesCheck:
   switch:
-      - condition: ${validateStoriesResult.response.body.result == true}
-        next: returnDuplicateIntentOrEntity
-  next: returnStoryIsMissing
+    - condition: ${validateStoriesResult.response.body.result == false}
+      next: returnDuplicateIntentOrEntity
+  next: getStoriesWithName
 
 getStoriesWithName:
-  call: http.get
+  call: http.post
   args:
     url: "[#TRAINING_PUBLIC_RUUTER]/rasa/stories"
     headers:
       cookie: ${incoming.headers.cookie}
+    body:
+      story: ${id}
   result: storiesResult
 
-checkIfStoryExists:
-  call: http.post
-  args:
-    url: "[#TRAINING_DMAPPER]/util/objectListContainsId"
-    body:
-      id: ${storyData.story}
-      list: ${storiesResult.response.body.response}
-  result: storiesCheckResult
-
-validateStories:
+validateStoryExists:
   switch:
-    - condition: ${storiesCheckResult.response.body.result == false}
-      next: returnStoryExists
+    - condition: ${storiesResult.response.body.response.data.id == id}
+      next: returnStoryIsMissing
   next: getFileLocations
 
 getFileLocations:
@@ -69,7 +62,7 @@ deleteStory:
   args:
     url: "[#TRAINING_DMAPPER]/dmapper/delete-story"
     body:
-      stories: ${storiesData.response.body.stories}
+      stories: ${storiesData.response.body}
       story_name: ${id}
   result: deleteStoriesData
 
@@ -78,7 +71,7 @@ mergeStories:
   args:
     url: "[#TRAINING_DMAPPER]/merge"
     body:
-      array1: ${deleteStoriesData.response.body.data}
+      array1: ${deleteStoriesData.response.body.data[1]}
       array2: ${[storyData]}
       iteratee: "story"
   result: mergedStories
@@ -88,7 +81,6 @@ convertJsonToYaml:
   args:
     url: "[#TRAINING_DMAPPER]/convert/json-to-yaml-stories"
     body:
-      version: "3.0"
       stories: ${mergedStories.response.body}
   result: storiesYaml
 
@@ -124,11 +116,6 @@ returnSuccess:
 
 returnStoryIsMissing:
   return: "Can't find story to update"
-  status: 409
-  next: end
-
-returnStoryExists:
-  return: "Story exists"
   status: 409
   next: end
 

--- a/GUI/src/pages/Training/Stories/StoriesDetail.tsx
+++ b/GUI/src/pages/Training/Stories/StoriesDetail.tsx
@@ -35,7 +35,6 @@ import './StoriesDetail.scss';
 import LoadingDialog from "../../../components/LoadingDialog";
 import {Rule, RuleDTO} from "../../../types/rule";
 
-
 const nodeTypes = {
   customNode: CustomNode,
 };
@@ -60,8 +59,8 @@ const initialNodes: Node[] = [
 const StoriesDetail: FC<{ mode: 'new' | 'edit' }> = ({ mode }) => {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>()
-  const [storyId, setStoryId] = useState<string | undefined>(id);
-  const [ruleId, setRuleId] = useState<string | undefined>(id);
+  const [currentEntityId, setCurrentEntityId] = useState<string | undefined>(id);
+  const location = useLocation();
   const navigate = useNavigate();
   const toast = useToast();
   const queryClient = useQueryClient();
@@ -69,8 +68,7 @@ const StoriesDetail: FC<{ mode: 'new' | 'edit' }> = ({ mode }) => {
   const [restartConfirmation, setRestartConfirmation] = useState(false);
   const [deleteId, setDeleteId] = useState('');
   const [editableTitle, setEditableTitle] = useState<string | null>(null);
-  const [story, setStory] = useState<Story | undefined | null>(null);
-  const [rule, setRule] = useState<Rule | undefined | null>(null);
+  const [currentEntity, setCurrentEntity] = useState<Story | Rule | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [category, setCategory] = useState<string>('stories');
 
@@ -78,13 +76,9 @@ const StoriesDetail: FC<{ mode: 'new' | 'edit' }> = ({ mode }) => {
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const onConnect = useCallback((params: Connection) => setEdges((eds) => addEdge(params, eds)), [setEdges]);
 
-  const { data: storyData, refetch: refetchStory } = useQuery<Story>({
-    queryKey: ['story-by-name', storyId],
-    enabled: !!storyId,
-  });
-  const { data: ruleData, refetch: refetchRule } = useQuery<Rule>({
-    queryKey: ['rule-by-name', ruleId],
-    enabled: !!ruleId,
+  const { data: currentEntityData, refetch: refetchCurrentEntity } = useQuery<Story | Rule>({
+    queryKey: [category === 'rules' ? 'rule-by-name' : 'story-by-name', currentEntityId],
+    enabled: !!currentEntityId,
   });
 
   const { data: intents } = useQuery<string[]>({
@@ -103,28 +97,34 @@ const StoriesDetail: FC<{ mode: 'new' | 'edit' }> = ({ mode }) => {
   useDocumentEscapeListener(() => setEditableTitle(null));
 
   useEffect(() => {
-    if (category === 'rules') {
-      setRule(ruleData ?? rule);
-    } else {
-      setStory(storyData ?? story);
+    if (location.state && location.state.category) {
+      setCategory(location.state.category);
     }
+
+    setCurrentEntity(currentEntityData ?? null);
 
     let nodes = [...initialNodes];
     let edges: any[] = [];
 
-    generateNodesFromStorySteps(storyData?.steps || story?.steps || ruleData?.steps || rule?.steps || [])
-      .forEach((x) => {
-        edges.push(generateNewEdge(nodes, edges));
-        nodes.push(generateNewNode({...x, nodes, handleNodeDelete, handleNodePayloadChange,}));
-      });
-      
+    generateNodesFromStorySteps(currentEntityData?.steps || currentEntity?.steps || [])
+        .forEach((x) => {
+          edges.push(generateNewEdge(nodes, edges));
+          nodes.push(generateNewNode({...x, nodes, handleNodeDelete, handleNodePayloadChange,}));
+        });
+
     setNodes(nodes);
     setEdges(edges);
 
-  }, [category, rule, ruleData, setEdges, setNodes, story, storyData]);
+  }, [location.state, category, currentEntity, currentEntityData]);
 
   const addStoryMutation = useMutation({
-    mutationFn: ({data, category}:{data: StoryDTO, category: string}) => addStoryOrRule(data, category),
+    mutationFn: ({ data, category }: { data: StoryDTO | RuleDTO, category: string }) => {
+      if (location.state.category === 'stories') {
+        return addStoryOrRule(data as StoryDTO, category);
+      } else {
+        return addStoryOrRule(data as RuleDTO, category);
+      }
+    },
     onMutate: () => setRefreshing(true),
     onSuccess: async () => {
       await queryClient.invalidateQueries(['stories']);
@@ -144,7 +144,13 @@ const StoriesDetail: FC<{ mode: 'new' | 'edit' }> = ({ mode }) => {
   });
 
   const editStoryMutation = useMutation({
-    mutationFn: ({ id, data, category }: { id: string, data: StoryDTO | RuleDTO, category: string }) => editStoryOrRule(id, data, category),
+    mutationFn: ({ id, data, category }: { id: string, data: StoryDTO | RuleDTO, category: string }) => {
+      if (location.state.category === 'stories') {
+        return editStoryOrRule(id, data as StoryDTO, category);
+      } else {
+        return editStoryOrRule(id, data as RuleDTO, category);
+      }
+    },
     onMutate: () => setRefreshing(true),
     onSuccess: async () => {
       await queryClient.invalidateQueries(['stories']);
@@ -165,7 +171,7 @@ const StoriesDetail: FC<{ mode: 'new' | 'edit' }> = ({ mode }) => {
   });
 
   const deleteStoryMutation = useMutation({
-    mutationFn: ({ id }: { id: string | number }) => deleteStoryOrRule(id),
+    mutationFn: ({ id }: { id: string | number }) => deleteStoryOrRule(id, location.state.category),
     onMutate: () => setRefreshing(true),
     onSuccess: async () => {
       await queryClient.invalidateQueries(['stories']);
@@ -247,7 +253,7 @@ const StoriesDetail: FC<{ mode: 'new' | 'edit' }> = ({ mode }) => {
     });
   }
 
-  const title = story?.story || t('global.title');
+  const title = currentEntityId || t('global.title');
 
   const handleGraphSave = async () => {
     const isRename = editableTitle && editableTitle !== id;
@@ -265,7 +271,7 @@ const StoriesDetail: FC<{ mode: 'new' | 'edit' }> = ({ mode }) => {
     }
 
     const data = {
-      story: editableTitle || id || title,
+      [category === 'stories' ? 'story' : 'rule']: editableTitle || id || title,
       steps: generateStoryStepsFromNodes(nodes),
     };
 
@@ -274,29 +280,29 @@ const StoriesDetail: FC<{ mode: 'new' | 'edit' }> = ({ mode }) => {
       addStoryMutation.mutate(data, category);
     }
     if (mode === 'edit' && id) {
-      editStoryMutation.mutate({id, data});
+      editStoryMutation.mutate({id, data, category});
     }
     await handleMutationLoadingAfterPopulateTable(data);
 
     if (isRename) {
       navigate(`/training/stories/${editableTitle}`, { replace: true });
       setEditableTitle(null);
-      setStory({ steps: story?.steps, story: editableTitle });
+      setCurrentEntity({ steps: story?.steps, story: editableTitle });
     }
   };
 
   const handleMutationLoadingAfterPopulateTable = async (data) => {
     let updatedData;
 
-    if (storyId === undefined || ruleId === undefined) {
+    if (setCurrentEntityId === undefined) {
       if (category === 'rules') {
-        setRuleId(editableTitle);
-        await refetchRule();
-        updatedData = refetchRule();
+        setCurrentEntityId(editableTitle);
+        await refetchCurrentEntity();
+        updatedData = refetchCurrentEntity();
       } else {
-        setStoryId(editableTitle);
-        await refetchStory();
-        updatedData = refetchStory();
+        setCurrentEntityId(editableTitle);
+        await refetchCurrentEntity();
+        updatedData = refetchCurrentEntity();
       }
     }
 

--- a/GUI/src/pages/Training/Stories/StoriesDetail.tsx
+++ b/GUI/src/pages/Training/Stories/StoriesDetail.tsx
@@ -307,7 +307,8 @@ const StoriesDetail: FC<{ mode: 'new' | 'edit' }> = ({ mode }) => {
     }
 
     updatedData.then((storyOrRuleObject) => {
-      if (mode === 'new' && (storyOrRuleObject.data != null && (storyOrRuleObject.data.story === editableTitle || storyOrRuleObject.data.rule === editableTitle))) {
+      if (mode === 'new' && (storyOrRuleObject.data != null && (storyOrRuleObject.data.story === editableTitle ||
+                                                                storyOrRuleObject.data.rule === editableTitle))) {
         setRefreshing(false);
       } else {
         setTimeout(() => {

--- a/GUI/src/pages/Training/Stories/index.tsx
+++ b/GUI/src/pages/Training/Stories/index.tsx
@@ -109,7 +109,7 @@ const Stories: FC = () => {
       cell: (props) => (
         <Button
           appearance='text'
-          onClick={() => navigate(`rules/${props.row.original.id}`)}
+          onClick={() => navigate(`rules/${props.row.original.id}`, { state: { category: 'rules' } })}
         >
           <Icon
             label={t('global.edit')}

--- a/GUI/src/types/rule.ts
+++ b/GUI/src/types/rule.ts
@@ -1,8 +1,8 @@
-import {ResponseData} from "./response";
+import { ResponseData } from "./response";
 
 export interface Rule {
   id: string;
-  steps: string | string[]
+  steps: string | string[];
 }
 
 export interface Rules {
@@ -10,4 +10,5 @@ export interface Rules {
 }
 
 export interface RuleDTO extends Omit<Rule, 'id'> {
+  rule: string;
 }


### PR DESCRIPTION
This PR adds the missing changes needed for the Rules updating to fully work and fixes the DSL errors for Story updating. Importantly, the StoryDetail page has been refactored to be more universal between both the Story and Rule objects, and all mutation queries work with both objects now. This PR also adds the more fully working validation for both operations and cleans up the previously made development that turned out a little too clunky. 