### PR TITLE
Fix additional slots and fields on YAML generation

### DIFF
--- a/DSL/DataMapper/js/convert/jsonToYamlStories.js
+++ b/DSL/DataMapper/js/convert/jsonToYamlStories.js
@@ -18,18 +18,18 @@ router.post('/', multer().array('file'), async (req, res) => {
                     switch (true) {
                         case !!step.intent:
                             formattedStep.intent = step.intent;
-                            break;
-                        case !!step.entities:
-                            formattedStep.entities = step.entities;
+                            if (step.entities && step.entities.length > 0) {
+                                formattedStep.entities = step.entities;
+                            }
                             break;
                         case !!step.action:
                             formattedStep.action = step.action;
                             break;
-                        case !!step.checkpoint:
-                            formattedStep.checkpoint = step.checkpoint;
-                            break;
-                        case !!step.slot_was_set && step.slot_was_set.length > 0:
+                        case !!step.slot_was_set && Object.keys(step.slot_was_set).length > 0:
                             formattedStep.slot_was_set = step.slot_was_set;
+                            break;
+                        case !!step.condition && step.condition.length > 0:
+                            formattedStep.condition = step.condition;
                             break;
                         default:
                             break;
@@ -48,18 +48,18 @@ router.post('/', multer().array('file'), async (req, res) => {
                     switch (true) {
                         case !!step.intent:
                             formattedStep.intent = step.intent;
-                            break;
-                        case !!step.entities:
-                            formattedStep.entities = step.entities;
+                            if (step.entities && step.entities.length > 0) {
+                                formattedStep.entities = step.entities;
+                            }
                             break;
                         case !!step.action:
                             formattedStep.action = step.action;
                             break;
-                        case !!step.checkpoint:
-                            formattedStep.checkpoint = step.checkpoint;
-                            break;
-                        case !!step.slot_was_set && step.slot_was_set.length > 0:
+                        case !!step.slot_was_set && Object.keys(step.slot_was_set).length > 0:
                             formattedStep.slot_was_set = step.slot_was_set;
+                            break;
+                        case !!step.condition && step.condition.length > 0:
+                            formattedStep.condition = step.condition;
                             break;
                         default:
                             break;

--- a/GUI/src/pages/Training/Stories/StoriesDetail.tsx
+++ b/GUI/src/pages/Training/Stories/StoriesDetail.tsx
@@ -278,7 +278,7 @@ const StoriesDetail: FC<{ mode: 'new' | 'edit' }> = ({ mode }) => {
 
     setRefreshing(true);
     if (mode === 'new') {
-      addStoryMutation.mutate({ data, category }); // Pass category here
+      addStoryMutation.mutate({ data, category });
     }
     if (mode === 'edit' && id) {
       editStoryMutation.mutate({id, data, category});


### PR DESCRIPTION
This PR fixes the incomplete YAML file generation by adding additional fields to the JSON-to-YAML (stories and rules specific) datamapper script. 