### PR TITLE
Story-Rules GUI Node and Data Clarifications

### DIFF
--- a/GUI/src/pages/Training/Stories/StoriesDetail.tsx
+++ b/GUI/src/pages/Training/Stories/StoriesDetail.tsx
@@ -341,20 +341,21 @@ const StoriesDetail: FC<{ mode: 'new' | 'edit' }> = ({ mode }) => {
     <Track gap={16} align='left' style={{ margin: '-16px' }}>
       <div style={{ flex: 1, maxWidth: 'calc(100% / 3)', padding: '16px 0 16px 16px' }}>
         <Track direction='vertical' gap={16} align='stretch'>
-        <Collapsible title={t('training.conditions')}>
-            <Track direction='vertical' align='stretch' gap={4}>
-              <button
-                onClick={() => handleNodeAdd({
-                  label: '',
-                  type: 'conditionNode',
-                  className: 'condition',
-                })}
-              >
-                <Box color='green'>condition</Box>
-              </button>
-            </Track>
-          </Collapsible>
-
+          {category === 'rules' && (
+              <Collapsible title={t('training.conditions')}>
+                <Track direction='vertical' align='stretch' gap={4}>
+                  <button
+                      onClick={() => handleNodeAdd({
+                        label: '',
+                        type: 'conditionNode',
+                        className: 'condition',
+                      })}
+                  >
+                    <Box color='green'>condition</Box>
+                  </button>
+                </Track>
+              </Collapsible>
+          )}
           {intents && Array.isArray(intents) && (
             <Collapsible title={t('training.intents.title')} defaultOpen>
               <Track direction='vertical' align='stretch' gap={4}>

--- a/GUI/src/services/rasa.tsx
+++ b/GUI/src/services/rasa.tsx
@@ -68,8 +68,6 @@ export const generateNodesFromStorySteps = (steps): Node[] =>
         let className;
 
         if (step.condition && Array.isArray(step.condition)) {
-            console.log("generate nodes")
-            console.log(step)
             type = 'conditionNode';
             className = 'condition';
             payload = {

--- a/GUI/src/services/rasa.tsx
+++ b/GUI/src/services/rasa.tsx
@@ -4,16 +4,29 @@ export const generateStoryStepsFromNodes = (nodes: Node[]) =>
     nodes.map(({ data: { type, label, payload, checkpoint }}) => {
         switch (type) {
             case 'intentNode':
-                return {
-                    intent: label,
-                    entities: payload.entities || [],
-                };
+                if (payload.entities === undefined) {
+                    return {
+                        intent: label,
+                        entities: [],
+                    };
+                } else if (payload.entities.length > 0 &&
+                    typeof payload.entities[0] === 'string') {
+                    return {
+                        intent: label,
+                        entities: payload.entities || []
+                    };
+                } else {
+                    return {
+                        intent: label,
+                        entities: payload.entities.map((entity) => entity.value) || [],
+                    };
+                }
             case 'responseNode':
-                return { action: label };
+                return { response: label };
             case 'formNode':
                 return {
-                    action: label,
-                    active_loop: payload.active_loop !== undefined ? payload.active_loop : null,
+                    form: label,
+                    active_loop: payload.active_loop !== undefined ? payload.active_loop : true,
                 };
             case 'slotNode':
                 return {
@@ -26,9 +39,22 @@ export const generateStoryStepsFromNodes = (nodes: Node[]) =>
                     ? { action: payload?.value || label }
                     : { action: label };
             case 'conditionNode':
+                let conditions: { active_loop?: any; slot?: any; value?: any; }[] = [];
+
+                payload.conditions.forEach((condition: { active_loop: { value: any; }; slot: { value: any; }; value: any; }) => {
+                    if (condition.active_loop) {
+                        conditions.push({ "active_loop": condition.active_loop.value });
+                    }
+                    if (condition.slot) {
+                        conditions.push({ "slot": condition.slot.value });
+                        conditions.push({ "value": condition.value });
+                    }
+                });
+
                 return {
-                    condition: payload.conditions || [],
+                    condition: conditions,
                 };
+
             default:
                 return null;
         }
@@ -42,6 +68,8 @@ export const generateNodesFromStorySteps = (steps): Node[] =>
         let className;
 
         if (step.condition && Array.isArray(step.condition)) {
+            console.log("generate nodes")
+            console.log(step)
             type = 'conditionNode';
             className = 'condition';
             payload = {
@@ -60,13 +88,16 @@ export const generateNodesFromStorySteps = (steps): Node[] =>
             type = 'intentNode';
             className = 'intent';
             label = step.intent;
-            payload = {
-                entities: step.entities?.map((entity) => {
-                    return {
-                        value: Object.keys(entity)[0],
-                    };
-                }) || [],
-            };
+            if (step.entities !== undefined) {
+                payload = {
+                    entities: step.entities.map((entityObj: {}) => {
+                        const key = Object.keys(entityObj)[0];
+                        return { label: key, value: key };
+                    }) || [],
+                };
+            } else {
+                payload = { entities: [] };
+            }
         } else if (step.action) {
             if (step.active_loop !== undefined) {
                 type = 'formNode';


### PR DESCRIPTION
This PR clarifies and unifies info display with stricter and more elaborate logic between story-rule page nodes and backend data.

Additionally, as requested from training, the 'conditions' clauses on the story-rules editing page can now only be displayed on opening a rule (not story).