### PR TITLE
Refactor all Training Module's Postgres queries to replace `UPDATE` queries with `INSERT` and `SELECT`

### DIFF
--- a/DSL/Resql/training/add-intent.sql
+++ b/DSL/Resql/training/add-intent.sql
@@ -1,6 +1,2 @@
 INSERT INTO intent (intent, created, status)
-VALUES (:intent, CURRENT_TIMESTAMP, :status)
-ON CONFLICT (id) DO UPDATE
-SET intent = EXCLUDED.intent,
-    created = EXCLUDED.created,
-    status = EXCLUDED.status;
+VALUES (:intent, CURRENT_TIMESTAMP, :status);


### PR DESCRIPTION
Related to:
- https://github.com/buerokratt/Training-Module/issues/487