### PR TITLE
698 Historical Chat links fix

### DIFF
--- a/GUI/package.json
+++ b/GUI/package.json
@@ -30,6 +30,7 @@
     "@tanstack/react-table": "^8.7.4",
     "linkify-react": "^4.1.1",
     "linkifyjs": "^4.1.1",
+    "markdown-to-jsx": "^7.5.0",
     "axios": "^1.2.1",
     "buffer": "^6.0.3",
     "clsx": "^1.2.1",

--- a/GUI/src/components/HistoricalChat/ChatMessage.tsx
+++ b/GUI/src/components/HistoricalChat/ChatMessage.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import { format } from 'date-fns';
 
 import { Message } from 'types/message';
-import Linkifier from "./linkifier";
+import Markdownify from "./Markdownify";
 
 type ChatMessageProps = {
   message: Message;
@@ -16,7 +16,7 @@ const ChatMessage: FC<ChatMessageProps> = ({ message, onMessageClick }) => {
                 className="historical-chat__message-text"
                 onClick={onMessageClick ? () => onMessageClick(message) : undefined}
             >
-                <Linkifier message={message.content ?? ''} />
+                <Markdownify message={message.content ?? ''} />
             </button>
             <time
                 dateTime={message.authorTimestamp}

--- a/GUI/src/components/HistoricalChat/HistoricalChat.scss
+++ b/GUI/src/components/HistoricalChat/HistoricalChat.scss
@@ -105,6 +105,10 @@
           background-color: get-color(sapphire-blue-10);
           color: get-color(white);
 
+          :any-link {
+            color:  get-color(white);
+          }
+
           &:hover {
             background-color: get-color(sapphire-blue-13);
           }
@@ -122,6 +126,10 @@
         &__message-text {
           background-color: get-color(black-coral-10);
           color: get-color(white);
+
+          :any-link {
+            color:  get-color(white);
+          }
 
           &:hover {
             background-color: #535665;
@@ -178,6 +186,10 @@
     line-height: $veera-line-height-500;
     transition: all .25s ease-out;
     cursor: pointer;
+
+    :any-link {
+      text-decoration:  underline;
+    }
 
     &:hover {
       background-color: get-color(black-coral-1);

--- a/GUI/src/components/HistoricalChat/Markdownify.tsx
+++ b/GUI/src/components/HistoricalChat/Markdownify.tsx
@@ -1,0 +1,13 @@
+import Markdown from 'markdown-to-jsx';
+
+const Markdownify = (props: { message: string | undefined }): JSX.Element => {
+  const { message = '' } = props;
+
+  return (
+    <div>
+      <Markdown options={{ enforceAtxHeadings: true }}>{message ?? ''}</Markdown>
+    </div>
+  );
+};
+
+export default Markdownify;


### PR DESCRIPTION
- Replaced Linkify with Markify
- Added new dependency
- Updated stylings to match chat-bot

Related [Task](https://github.com/buerokratt/Training-Module/issues/698).