### PR TITLE
Fix/1099 fix markdown formatting

### DIFF
--- a/GUI/src/components/HistoricalChat/HistoricalChat.scss
+++ b/GUI/src/components/HistoricalChat/HistoricalChat.scss
@@ -236,7 +236,7 @@
 .reset {
   margin: 0;
   padding: 0;
-  line-height: 1.5;
+  line-height: 1.3;
 }
 
 .reset h1,
@@ -250,13 +250,13 @@
 }
 
 .reset p {
-  margin: 0;
+  margin:  0 0 0.5rem;
   padding: 0;
 }
 
 .reset ul,
 .reset ol {
-  margin: 0;
+  margin: 0 0 1rem;
   padding-left: 1.5rem;
 }
 

--- a/GUI/src/components/HistoricalChat/HistoricalChat.scss
+++ b/GUI/src/components/HistoricalChat/HistoricalChat.scss
@@ -232,3 +232,40 @@
     line-height: 20px;
   }
 }
+
+.reset {
+  margin: 0;
+  padding: 0;
+  line-height: 1.5;
+}
+
+.reset h1,
+.reset h2,
+.reset h3,
+.reset h4,
+.reset h5,
+.reset h6 {
+  margin: 0;
+  padding: 0;
+}
+
+.reset p {
+  margin: 0;
+  padding: 0;
+}
+
+.reset ul,
+.reset ol {
+  margin: 0;
+  padding-left: 1.5rem;
+}
+
+.reset li {
+  margin: 0;
+  padding: 0;
+}
+
+.reset a {
+  text-decoration: none;
+  color: inherit;
+}

--- a/GUI/src/components/HistoricalChat/Markdownify.tsx
+++ b/GUI/src/components/HistoricalChat/Markdownify.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import Markdown from 'markdown-to-jsx';
+import './HistoricalChat.scss';
 
 interface MarkdownifyProps {
   message: string | undefined;
@@ -22,7 +23,7 @@ const LinkPreview: React.FC<{ href: string }> = ({ href }) => {
 };
 
 const Markdownify: React.FC<MarkdownifyProps> = ({ message }) => (
-  <div>
+  <div className={'reset'}>
     <Markdown
       options={{
         enforceAtxHeadings: true,


### PR DESCRIPTION
- Added style reset to reflect indentations.

Related [task](https://github.com/buerokratt/Buerokratt-Chatbot/issues/1099).