### PR TITLE
Fix UI not always updating on deleting an intent

### DIFF
--- a/GUI/src/pages/Training/Intents/CommonIntents.tsx
+++ b/GUI/src/pages/Training/Intents/CommonIntents.tsx
@@ -14,7 +14,7 @@ import IntentList from './IntentList';
 const CommonIntents: FC = () => {
   const { t } = useTranslation();
 
-  const { intents, selectedIntent, setSelectedIntent, queryRefresh, isLoading } = useIntentsData({
+  const { intents, setIntents, selectedIntent, setSelectedIntent, queryRefresh, isLoading } = useIntentsData({
     queryKey: 'intents/with-examples-count?prefix=common_',
   });
 
@@ -117,7 +117,7 @@ const CommonIntents: FC = () => {
             <IntentDetails
               intentId={selectedIntent.id}
               setSelectedIntent={setSelectedIntent}
-              listRefresh={queryRefresh}
+              setListIntents={setIntents}
             />
           )}
         </Tabs.Root>

--- a/GUI/src/pages/Training/Intents/IntentDetails.tsx
+++ b/GUI/src/pages/Training/Intents/IntentDetails.tsx
@@ -87,9 +87,6 @@ const IntentDetails: FC<IntentDetailsProps> = ({ intentId, setSelectedIntent, li
         `response-by-intent-id?intent=${intentId}`,
       ]);
       setResponse(responseResponse.response);
-
-      // const rulesResponse = await queryClient.fetchQuery<RuleResponse>([`rule-by-intent-id?intent=${intentId}`]);
-      // setIntentRule(rulesResponse.response.id);
     },
     [intentId, queryClient, setResponse, setSelectedIntent]
   );

--- a/GUI/src/pages/Training/Intents/IntentDetails.tsx
+++ b/GUI/src/pages/Training/Intents/IntentDetails.tsx
@@ -44,12 +44,10 @@ interface IntentResponse {
 interface IntentDetailsProps {
   intentId: string;
   setSelectedIntent: Dispatch<SetStateAction<IntentWithExamplesCount | null>>;
-  // todo remove
-  listRefresh?: (newIntent?: string) => Promise<void>;
   setListIntents: Dispatch<SetStateAction<IntentWithExamplesCount[]>>;
 }
 
-const IntentDetails: FC<IntentDetailsProps> = ({ intentId, setSelectedIntent, listRefresh, setListIntents }) => {
+const IntentDetails: FC<IntentDetailsProps> = ({ intentId, setSelectedIntent, setListIntents }) => {
   const [intent, setIntent] = useState<Intent | null>(null);
 
   const [editingIntentTitle, setEditingIntentTitle] = useState<string | null>(null);

--- a/GUI/src/pages/Training/Intents/IntentDetails.tsx
+++ b/GUI/src/pages/Training/Intents/IntentDetails.tsx
@@ -21,7 +21,7 @@ import { useToast } from 'hooks/useToast';
 import { ROLES } from 'hoc/with-authorization';
 import useStore from '../../../store/store';
 import { editResponse } from 'services/responses';
-import { addStoryOrRule, deleteStoryOrRule } from 'services/stories';
+import { addStoryOrRule } from 'services/stories';
 import { RuleDTO } from 'types/rule';
 import ConnectServiceToIntentModal from 'pages/ConnectServiceToIntentModal';
 import LoadingDialog from 'components/LoadingDialog';
@@ -44,10 +44,12 @@ interface IntentResponse {
 interface IntentDetailsProps {
   intentId: string;
   setSelectedIntent: Dispatch<SetStateAction<IntentWithExamplesCount | null>>;
-  listRefresh: (newIntent?: string) => Promise<void>;
+  // todo remove
+  listRefresh?: (newIntent?: string) => Promise<void>;
+  setListIntents: Dispatch<SetStateAction<IntentWithExamplesCount[]>>;
 }
 
-const IntentDetails: FC<IntentDetailsProps> = ({ intentId, setSelectedIntent, listRefresh }) => {
+const IntentDetails: FC<IntentDetailsProps> = ({ intentId, setSelectedIntent, listRefresh, setListIntents }) => {
   const [intent, setIntent] = useState<Intent | null>(null);
 
   const [editingIntentTitle, setEditingIntentTitle] = useState<string | null>(null);
@@ -403,10 +405,9 @@ const IntentDetails: FC<IntentDetailsProps> = ({ intentId, setSelectedIntent, li
       setShowConnectToServiceModal(false);
     },
     onSuccess: async () => {
+      setListIntents((prev) => prev.filter((intent) => intent.id !== intentId));
       setSelectedIntent(null);
-      await queryClient.invalidateQueries(['intents/with-examples-count']);
-      // Without the delay, back end still returns the deleted intent. Perhaps BE is deleting asynchronously?
-      setTimeout(() => listRefresh(), 300);
+
       toast.open({
         type: 'success',
         title: t('global.notification'),

--- a/GUI/src/pages/Training/Intents/index.tsx
+++ b/GUI/src/pages/Training/Intents/index.tsx
@@ -17,7 +17,7 @@ const Intents: FC = () => {
   const { t } = useTranslation();
   const toast = useToast();
 
-  const { intents, selectedIntent, setSelectedIntent, queryRefresh, isLoading } = useIntentsData({
+  const { intents, setIntents, selectedIntent, setSelectedIntent, queryRefresh, isLoading } = useIntentsData({
     queryKey: 'intents/with-examples-count',
   });
 
@@ -31,6 +31,8 @@ const Intents: FC = () => {
     },
     [intents, setSelectedIntent]
   );
+
+  console.log('render intents', intents);
 
   const newIntentMutation = useMutation({
     mutationFn: (data: { name: string }) => addIntent(data),
@@ -108,7 +110,8 @@ const Intents: FC = () => {
             <IntentDetails
               intentId={selectedIntent.id}
               setSelectedIntent={setSelectedIntent}
-              listRefresh={queryRefresh}
+              // listRefresh={queryRefresh}
+              setListIntents={setIntents}
             />
           )}
         </Tabs.Root>

--- a/GUI/src/pages/Training/Intents/index.tsx
+++ b/GUI/src/pages/Training/Intents/index.tsx
@@ -32,8 +32,6 @@ const Intents: FC = () => {
     [intents, setSelectedIntent]
   );
 
-  console.log('render intents', intents);
-
   const newIntentMutation = useMutation({
     mutationFn: (data: { name: string }) => addIntent(data),
     onMutate: () => {
@@ -110,7 +108,6 @@ const Intents: FC = () => {
             <IntentDetails
               intentId={selectedIntent.id}
               setSelectedIntent={setSelectedIntent}
-              // listRefresh={queryRefresh}
               setListIntents={setIntents}
             />
           )}

--- a/GUI/src/pages/Training/Intents/useIntentsData.ts
+++ b/GUI/src/pages/Training/Intents/useIntentsData.ts
@@ -62,6 +62,7 @@ export const useIntentsData = ({ queryKey }: UseIntentsDataProps) => {
 
   return {
     intents,
+    setIntents,
     selectedIntent,
     setSelectedIntent,
     queryRefresh,


### PR DESCRIPTION
Related task: https://github.com/buerokratt/Training-Module/issues/787

This PR:
- Fixes [an issue](https://github.com/buerokratt/Training-Module/issues/787#issuecomment-2592890321) with UI not always updating to reflect intent deletion. This previously used a flaky approach with hardcoded timeout. Refactored this to update UI optimistically on receiving a success response from the back-end.
- Also removed redundant `deleteRuleWithIntentMutation` logic as we are deleting rules with `deleteIntentMutation` anyway. It also allows to get rid of the extra rule request.