### PR TITLE
Fix/813 intents count

### DIFF
--- a/DSL/OpenSearch/templates/intents-with-examples-count.json
+++ b/DSL/OpenSearch/templates/intents-with-examples-count.json
@@ -12,7 +12,7 @@
           "aggs": {
             "examples_counts": {
               "value_count": {
-                "field": "examples"
+                "field": "examples.raw"
               }
             }
           }

--- a/GUI/src/pages/Training/Intents/IntentDetails.tsx
+++ b/GUI/src/pages/Training/Intents/IntentDetails.tsx
@@ -46,9 +46,10 @@ interface IntentDetailsProps {
   intentId: string;
   setSelectedIntent: Dispatch<SetStateAction<IntentWithExamplesCount | null>>;
   setListIntents: Dispatch<SetStateAction<IntentWithExamplesCount[]>>;
+  updateIntentsCount: () => void;
 }
 
-const IntentDetails: FC<IntentDetailsProps> = ({ intentId, setSelectedIntent, setListIntents }) => {
+const IntentDetails: FC<IntentDetailsProps> = ({ intentId, setSelectedIntent, setListIntents,updateIntentsCount }) => {
   const [intent, setIntent] = useState<Intent | null>(null);
 
   const [editingIntentTitle, setEditingIntentTitle] = useState<string | null>(null);
@@ -172,7 +173,7 @@ const IntentDetails: FC<IntentDetailsProps> = ({ intentId, setSelectedIntent, se
       newName,
     });
 
-    queryRefresh(newName);
+    await queryRefresh(newName);
   };
 
   const isValidDate = (dateString: string | number | Date) => {
@@ -552,7 +553,7 @@ const IntentDetails: FC<IntentDetailsProps> = ({ intentId, setSelectedIntent, se
         {intent?.examples && (
           <Track align="stretch" justify="between" gap={10} style={{ width: '100%' }}>
             <div style={{ flex: 1 }}>
-              <IntentExamplesTable intent={intent} updateSelectedIntent={updateSelectedIntent} />
+              <IntentExamplesTable intent={intent} updateSelectedIntent={updateSelectedIntent} reFetchIntents={updateIntentsCount} />
             </div>
             <div>
               <Track align="right" justify="between" direction="vertical" gap={100}>

--- a/GUI/src/pages/Training/Intents/IntentExamplesTable.tsx
+++ b/GUI/src/pages/Training/Intents/IntentExamplesTable.tsx
@@ -21,9 +21,10 @@ import { getEntities } from 'services/entities';
 type IntentExamplesTableProps = {
   intent: Intent;
   updateSelectedIntent: (intent: Intent) => void;
+  reFetchIntents: () => void;
 };
 
-const IntentExamplesTable: FC<IntentExamplesTableProps> = ({ intent, updateSelectedIntent }) => {
+const IntentExamplesTable: FC<IntentExamplesTableProps> = ({ intent, updateSelectedIntent, reFetchIntents }) => {
   let updatedExampleTitle = '';
   const { t } = useTranslation();
   const toast = useToast();
@@ -143,6 +144,7 @@ const IntentExamplesTable: FC<IntentExamplesTableProps> = ({ intent, updateSelec
       });
       updateSelectedIntent(intent);
       deleteExampleFromList(oldExampleText);
+      reFetchIntents();
     },
     onError: (error: AxiosError) => {
       toast.open({
@@ -169,6 +171,7 @@ const IntentExamplesTable: FC<IntentExamplesTableProps> = ({ intent, updateSelec
         title: t('global.notification'),
         message: t('toast.newExampleAdded'),
       });
+      reFetchIntents();
     },
     onError: (error: AxiosError) => {
       toast.open({

--- a/GUI/src/pages/Training/Intents/index.tsx
+++ b/GUI/src/pages/Training/Intents/index.tsx
@@ -108,6 +108,7 @@ const Intents: FC = () => {
             <IntentDetails
               intentId={selectedIntent.id}
               setSelectedIntent={setSelectedIntent}
+              updateIntentsCount={queryRefresh}
               setListIntents={setIntents}
             />
           )}


### PR DESCRIPTION
- Updated OS script to properly display number of examples per intent on a page.
- Added re fetching intents after example was added/removed

Related [task](https://github.com/buerokratt/Training-Module/issues/819).