### PR TITLE
Hot-Fix: DataMapper Url in intent-ids

### DIFF
--- a/DSL/Ruuter.private/training/GET/rasa/intent-ids.yml
+++ b/DSL/Ruuter.private/training/GET/rasa/intent-ids.yml
@@ -29,7 +29,7 @@ getIntents:
 mapIntentsData:
   call: http.post
   args:
-    url: "[#TRAINING_DMAPPER]/hbs/training/get_intent_ids"
+    url: "[#TRAINING_DMAPPER_HBS]/get_intent_ids"
     headers:
       type: "json"
     body:


### PR DESCRIPTION
- Modified Data Mapper Url [#TRAINING_DMAPPER]/hbs/training to [#TRAINING_DMAPPER_HBS]