### PR TITLE
1523 forwarded message

### DIFF
--- a/GUI/translations/en/common.json
+++ b/GUI/translations/en/common.json
@@ -331,6 +331,8 @@
       "popupNotifications": "Popup notifications",
       "newUnansweredChat": "New unanswered chat",
       "newForwardedChat": "New forwarded chat",
+      "newForwardedChatTitle": "Forwarded chat",
+      "newForwardedChatMessage": "You have new forwarded chat!",
       "newValidationMessage": "New message to validate",
       "useAutocorrect": "Text auto corrector",
       "statusCommentUpdated": "Status clarification updated"

--- a/GUI/translations/et/common.json
+++ b/GUI/translations/et/common.json
@@ -334,6 +334,8 @@
       "popupNotifications": "Pop-up märguanded",
       "newUnansweredChat": "Uus vastamata vestlus",
       "newForwardedChat": "Uus suunatud vestlus",
+      "newForwardedChatTitle": "Suunatud vestlus",
+      "newForwardedChatMessage": "Sulle suunati uus vestlus!",
       "newValidationMessage": "Uus teade kinnitamiseks",
       "useAutocorrect": "Teksti autokorrektor",
       "statusCommentUpdated": "Staatuse täpsustus uuendatud"


### PR DESCRIPTION
- Added missing translation keys.

Related [task](https://github.com/buerokratt/Buerokratt-Chatbot/issues/1523).